### PR TITLE
Fix L0 regression

### DIFF
--- a/src/integration/test_suites/mcu_lmem_exe/mcu_lmem_exe.s
+++ b/src/integration/test_suites/mcu_lmem_exe/mcu_lmem_exe.s
@@ -17,7 +17,7 @@ _start:
     csrw 0x7c0, x1
 
     # Jump to main in RAM
-    la a0, 0x80010000    # Load the address of the main program in RAM into a0
+    la a0, 0x90010000    # Load the address of the main program in RAM into a0
     jalr ra, 0(a0)       # Jump to the address in a0 and link return address to ra
 
 _finish:

--- a/tools/scripts/Makefile
+++ b/tools/scripts/Makefile
@@ -305,8 +305,9 @@ else
 mcu_program.hex: $(OFILE_CRT) $(OFILES) $(LINK)
 	@echo Building $(TESTNAME)
 	$(GCC_PREFIX)-gcc $(ABI) -Wl,-Map=$(TESTNAME).map -lgcc -T$(LINK) -o $(TESTNAME).exe $(OFILE_CRT) $(OFILES) -nostartfiles  $(TEST_LIBS)
-	-$(GCC_PREFIX)-objcopy --dump-section .dccm=dccm_section.bin $(TESTNAME).exe
-	-$(GCC_PREFIX)-objcopy -O verilog -I binary dccm_section.bin mcu_dccm.hex
+#	-$(GCC_PREFIX)-objcopy --dump-section .dccm=dccm_section.bin $(TESTNAME).exe
+#	-$(GCC_PREFIX)-objcopy -O verilog -I binary dccm_section.bin mcu_dccm.hex
+	-$(GCC_PREFIX)-objcopy -O verilog -j .dccm --change-section-lma .dccm-0x50000000 --pad-to 0x4000 --no-change-warnings $(TESTNAME).exe mcu_dccm.hex
 	-$(GCC_PREFIX)-objcopy -O verilog -R .data -R .rodata -R .srodata -R .bss -R .sbss -R .data.io -R .eh_frame --pad-to 0x20000 --no-change-warnings $(TESTNAME).exe mcu_program.hex
 	-$(GCC_PREFIX)-objcopy -O binary           -R .data.io -R .eh_frame --pad-to 0xC000 --no-change-warnings $(TESTNAME).exe mcu_program.bin
 	-$(GCC_PREFIX)-objcopy -O verilog -R .text -R .data.io -R .eh_frame --pad-to 0x20000 --no-change-warnings $(TESTNAME).exe mcu_lmem.hex


### PR DESCRIPTION
Fix DCCM section extraction (to avoid 'ignored' error in regressions) and update hardcoded address in mcu_lmem_exe.s