### PR TITLE
Fix compilespecs.yml

### DIFF
--- a/config/compilespecs.yml
+++ b/config/compilespecs.yml
@@ -1,4 +1,4 @@
-name: caliptra-ss_lib
+name: caliptra_ss_lib
 files:
   # Components
   - src/mcu/config/compile.yml


### PR DESCRIPTION
Avoid the '-' character in lib name, which is not parsed.