### PR TITLE
Ckuchta msft mci

### DIFF
--- a/config/compilespecs.yml
+++ b/config/compilespecs.yml
@@ -11,6 +11,7 @@ files:
   - src/axi2tlul/config/compile.yml
   - src/caliptra_ss_lc_ctrl/config/compile.yml
   - src/fuse_ctrl/config/compile.yml
+  - src/mci/config/compile.yml
   - third_party/caliptra-rtl/src/libs/config/compile.yml
   - third_party/caliptra-rtl/src/ahb_lite_bus/config/compile.yml
   - third_party/caliptra-rtl/src/riscv_core/veer_el2/config/compile.yml

--- a/src/mci/config/compile.yml
+++ b/src/mci/config/compile.yml
@@ -15,18 +15,24 @@ schema_version: 2.4.0
 requires:
   - caliptra_prim
   - axi_sub
-  - soc_ifc_top
   - mci_pkg
+  # for beh_lib with rvecc_encode/decode
+  - el2_veer_pkg
 targets:
   rtl:
     directories:
       - $COMPILE_ROOT/rtl
     files:
-      - $COMPILE_ROOT/rtl/mci_boot_seqr.sv
       - $COMPILE_ROOT/rtl/mci_top.sv
+      - $COMPILE_ROOT/rtl/mci_axi_sub_decode.sv
+      - $COMPILE_ROOT/rtl/mci_axi_sub_top.sv
+      - $COMPILE_ROOT/rtl/mci_mcu_sram_ctrl.sv
+      - $COMPILE_ROOT/rtl/mci_mcu_sram_if.sv
+      - $COMPILE_ROOT/rtl/cif_if.sv
     tops: [mci_top]
   rtl_lint:
     directories: [$COMPILE_ROOT/config/design_lint]
     waiver_files:
       - $MSFT_REPO_ROOT/src/mci/config/design_lint/mci/sglint_waivers
     tops: [mci_top]
+

--- a/src/mci/config/compile.yml
+++ b/src/mci/config/compile.yml
@@ -1,0 +1,32 @@
+provides: [mci_pkg]
+schema_version: 2.4.0
+targets:
+  rtl:
+    directories: [$COMPILE_ROOT/rtl]
+    files:
+      - $COMPILE_ROOT/rtl/mci_pkg.sv
+  tb:
+    directories: [$COMPILE_ROOT/rtl]
+    files:
+      - $COMPILE_ROOT/rtl/mci_pkg.sv
+---
+provides: [mci_top]
+schema_version: 2.4.0
+requires:
+  - caliptra_prim
+  - axi_sub
+  - soc_ifc_top
+  - mci_pkg
+targets:
+  rtl:
+    directories:
+      - $COMPILE_ROOT/rtl
+    files:
+      - $COMPILE_ROOT/rtl/mci_boot_seqr.sv
+      - $COMPILE_ROOT/rtl/mci_top.sv
+    tops: [mci_top]
+  rtl_lint:
+    directories: [$COMPILE_ROOT/config/design_lint]
+    waiver_files:
+      - $MSFT_REPO_ROOT/src/mci/config/design_lint/mci/sglint_waivers
+    tops: [mci_top]

--- a/src/mci/rtl/cif_if.sv
+++ b/src/mci/rtl/cif_if.sv
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Description:
+//      Signals for caliptra's internal fabric interface
+//
+
+interface cif_if #(parameter integer ADDR_WIDTH = 32, parameter integer DATA_WIDTH = 32, parameter integer ID_WIDTH = 8, parameter integer USER_WIDTH = 32) (input logic clk, input logic rst_b);
+
+    typedef struct packed {
+        logic                       write;
+        logic   [ADDR_WIDTH-1:0]    addr;
+        logic   [DATA_WIDTH-1:0]    wdata;
+        logic   [DATA_WIDTH/8-1:0]  wstrb;
+        logic   [2:0]               size;
+        logic                       last;
+        logic   [USER_WIDTH-1:0]    user;
+        logic   [ID_WIDTH-1:0]      id;
+    } cif_req_data_t;
+
+    logic                       dv;
+    logic                       hold;
+    logic                       write;
+    logic   [DATA_WIDTH-1:0]    rdata;
+    logic                       error;
+    cif_req_data_t              req_data;
+
+
+    // Modport for read manager
+    modport request (
+
+        output  dv,
+        output  req_data,
+        
+        input   hold,
+        input   rdata,
+        input   error
+    );
+
+    // Modport for write manager
+    modport response (
+        input   dv,
+        input   req_data,
+        
+        output  hold,
+        output  rdata,
+        output  error
+    );
+
+endinterface

--- a/src/mci/rtl/mci_axi_sub_decode.sv
+++ b/src/mci/rtl/mci_axi_sub_decode.sv
@@ -1,0 +1,108 @@
+
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Description:
+//      Decodes the SOC request and sends to appropriate target.
+//
+
+module mci_axi_sub_decode 
+    import mci_pkg::*;
+    #(
+    // Configurable memory blocks
+    parameter MCU_SRAM_SIZE_KB = 1024,
+    parameter MBOX0_SIZE_KB    = 4, // KB
+    parameter MBOX1_SIZE_KB    = 4, // KB
+
+
+    ///////////////////////////////////////////////////////////
+    // MCI Memory Map
+    ///////////////////////////////////////////////////////////
+    localparam CSR_SIZE_KB           = 512, // FIXME should I expose? KB
+    localparam CSR_START_ADDR        = 32'h0000_0000,
+    localparam CSR_END_ADDR          = CSR_START_ADDR + (CSR_SIZE_KB * KB) - 1,
+    localparam MBOX0_START_ADDR      = 32'h0008_0000,
+    localparam MBOX0_END_ADDR        = MBOX0_START_ADDR + (MBOX0_SIZE_KB * KB) - 1,
+    localparam MBOX1_START_ADDR      = MBOX0_END_ADDR + 32'h0000_0001, // FIXME: Do we want B2B
+    localparam MBOX1_END_ADDR        = MBOX1_START_ADDR + (MBOX1_SIZE_KB * KB) - 1,
+    localparam MCU_SRAM_START_ADDR   = 32'h0002_0000,
+    localparam MCU_SRAM_END_ADDR     = MCU_SRAM_START_ADDR + (MCU_SRAM_SIZE_KB * KB) - 1
+
+        
+    )
+    (
+    //SOC inf
+    cif_if.response  soc_resp_if,
+
+    //MCU SRAM inf
+    cif_if.request  mcu_sram_req_if 
+);
+
+// GRANT signals
+logic soc_mcu_sram_gnt;
+
+// MISC signals
+logic soc_req_miss;
+
+
+///////////////////////////////////////////////////////////
+// Decode which address space is being requested
+///////////////////////////////////////////////////////////
+//SoC requests to MCU_SRAM
+always_comb soc_mcu_sram_gnt = (soc_resp_if.dv & (soc_resp_if.req_data.addr inside {[MCU_SRAM_START_ADDR:MCU_SRAM_END_ADDR]}));
+
+
+///////////////////////////////////////////////////////////
+// Drive DV to appropriate destination
+///////////////////////////////////////////////////////////
+
+// MCU SRAM
+always_comb mcu_sram_req_if.dv = soc_mcu_sram_gnt;
+
+
+///////////////////////////////////////////////////////////
+// Drive data and reqest to approriate destination.
+///////////////////////////////////////////////////////////
+
+// MCU SRAM
+always_comb mcu_sram_req_if.req_data = soc_resp_if.req_data;
+
+
+
+///////////////////////////////////////////////////////////
+// Drive read data back
+///////////////////////////////////////////////////////////
+
+assign soc_resp_if.rdata = soc_mcu_sram_gnt ? mcu_sram_req_if.rdata : '0;
+
+
+///////////////////////////////////////////////////////////
+// Drive approriate hold back
+///////////////////////////////////////////////////////////
+
+always_comb soc_resp_if.hold = (soc_mcu_sram_gnt & (~soc_mcu_sram_gnt | mcu_sram_req_if.hold));
+
+
+///////////////////////////////////////////////////////////
+// Drive approriate error back or request misses all desitnations
+///////////////////////////////////////////////////////////
+
+// Missed all destinations 
+always_comb soc_req_miss = soc_resp_if.dv & ~(soc_mcu_sram_gnt);
+
+// Error for SOC
+always_comb soc_resp_if.error = (soc_mcu_sram_gnt & mcu_sram_req_if.error) |
+                        soc_req_miss;
+
+endmodule

--- a/src/mci/rtl/mci_axi_sub_top.sv
+++ b/src/mci/rtl/mci_axi_sub_top.sv
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Description:
+//      Translates AXI requests to internal fabric. Decoding the requests
+//      and sending to the appropriate target.
+//
+
+
+module mci_axi_sub_top 
+    #(
+    parameter MCU_SRAM_SIZE_KB  = 1024,
+    parameter MBOX0_SIZE_KB    = 4,
+    parameter MBOX1_SIZE_KB    = 4
+    )
+    (
+    input logic clk,
+
+    // MCI Resets
+    input logic rst_b,
+
+    // MCI AXI Interface
+    axi_if.w_sub s_axi_w_if,
+    axi_if.r_sub s_axi_r_if,
+
+    // MCU SRAM Interface
+    cif_if.request  mcu_sram_req_if
+
+    );
+
+localparam AXI_ADDR_WIDTH = s_axi_w_if.AW;
+localparam AXI_DATA_WIDTH = s_axi_w_if.DW;
+localparam AXI_USER_WIDTH = s_axi_w_if.UW;
+localparam AXI_ID_WIDTH   = s_axi_w_if.IW;
+
+// Interface between axi_sub and mci decoder
+cif_if #(
+    .ADDR_WIDTH(AXI_ADDR_WIDTH), 
+    .DATA_WIDTH(AXI_DATA_WIDTH), 
+    .ID_WIDTH(AXI_ID_WIDTH),
+    .USER_WIDTH(AXI_USER_WIDTH)
+    )
+    soc_resp_if(
+        .clk,
+        .rst_b(rst_b)
+    );
+
+//AXI Interface
+//This module contains the logic for interfacing with the SoC over the AXI Interface
+//The SoC sends read and write requests using AXI Protocol
+//This wrapper decodes that protocol, collapses the full-duplex protocol to
+// simplex, and issues requests to the MIC decode block
+axi_sub #(
+    .AW   (AXI_ADDR_WIDTH),
+    .DW   (AXI_DATA_WIDTH),
+    .UW   (AXI_USER_WIDTH),
+    .IW   (AXI_ID_WIDTH  ),
+    .EX_EN(0             ),
+    .C_LAT(0             )
+) i_axi_sub (
+    .clk  (clk     ),
+    .rst_n(rst_b), 
+
+    // AXI INF
+    .s_axi_w_if(s_axi_w_if),
+    .s_axi_r_if(s_axi_r_if),
+
+    //COMPONENT INF
+    .dv    (soc_resp_if.dv  ),
+    .addr  (soc_resp_if.req_data.addr    ), // Byte address
+    .write (soc_resp_if.req_data.write   ),
+    .user  (soc_resp_if.req_data.user    ), 
+    .id    (soc_resp_if.req_data.id      ),
+    .wdata (soc_resp_if.req_data.wdata   ), // Requires: Component dwidth == AXI dwidth
+    .wstrb (soc_resp_if.req_data.wstrb   ), // FIXME unused today Requires: Component dwidth == AXI dwidth
+    .rdata (soc_resp_if.rdata   ), // Requires: Component dwidth == AXI dwidth
+    .last  (soc_resp_if.req_data.last), // FIXME unused in code today Asserted with final 'dv' of a burst
+    .hld   (soc_resp_if.hold    ),
+    .rd_err(soc_resp_if.error   ),
+    .wr_err(soc_resp_if.error   )
+);
+
+assign soc_resp_if.req_data.size = '0; // FIXME unused?
+
+//AXI Interface
+//This module contains the logic for interfacing with the SoC over the AXI Interface
+//The SoC sends read and write requests using AXI Protocol
+//This wrapper decodes that protocol, collapses the full-duplex protocol to
+// simplex, and issues requests to the MIC decode block
+mci_axi_sub_decode #(
+    .MCU_SRAM_SIZE_KB   (MCU_SRAM_SIZE_KB),
+    .MBOX0_SIZE_KB   (MBOX0_SIZE_KB),
+    .MBOX1_SIZE_KB   (MBOX1_SIZE_KB)
+) i_mci_axi_sub_decode (
+    //SOC inf
+    .soc_resp_if        (soc_resp_if.response),
+
+    //MCU SRAM inf
+    .mcu_sram_req_if    (mcu_sram_req_if)
+);
+
+//req from axi is for soc always
+// always_comb soc_req.soc_req = 1'b1; FIXME remove?
+
+
+
+endmodule

--- a/src/mci/rtl/mci_boot_seqr.sv
+++ b/src/mci/rtl/mci_boot_seqr.sv
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module mci_boot_seqr #(
+    parameter myparam = "fixme"
+) (
+    input logic clk,
+    input logic rst_n,
+
+    output logic fabric_rst_b,
+    output logic fc_rst_b,
+    output logic lcc_rst_b,
+    output logic tap_rst_b,
+    output logic mcu_rst_b,
+    output logic cptra_rst_b
+);
+
+endmodule

--- a/src/mci/rtl/mci_mcu_sram_ctrl.sv
+++ b/src/mci/rtl/mci_mcu_sram_ctrl.sv
@@ -1,0 +1,335 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Description:
+//      This module is used to control requests going to a single MCU SRAM.
+//      Requests come in through the cif_resp_if and are passed the the SRAM
+//      on the mci_mcu_sram_req_if. 
+//
+//      Fabric Limitations:
+//      The integrator and higher level fabric is responsible for routing appropriate 
+//      requests to the MCU SRAM as this module cannot detect address aliasing.
+//
+//      Error handling:
+//      If an access vilation due to USER privilage issues is detected it 
+//      will always return an error on the first cycle of the cif_if.
+//      ECC errors are returned on the read data phase (second clock cycle)
+//
+//      Region mapping:
+//      The lower address is mapped to the exec region. Upper address range is mapped
+//      to prot region. If fw_sram_exec_region_size is larger than the actual SRAM size 
+//      the entier SRAM is considered exec region and there is no prot region
+
+module mci_mcu_sram_ctrl 
+    #(
+    parameter  MCU_SRAM_SIZE_KB = 1024
+    )
+    (
+    input logic clk,
+
+    // MCI Resets
+    input logic rst_b,
+
+    // Interface
+    input logic [15:0] fw_sram_exec_region_size, // 4KB steps with 0 being 4KB
+
+    // Caliptra internal fabric response interface
+    cif_if.response  cif_resp_if,
+
+    // AXI users
+    input logic [cif_resp_if.USER_WIDTH-1:0] strap_mcu_lsu_axi_user,
+    input logic [cif_resp_if.USER_WIDTH-1:0] strap_mcu_ifu_axi_user,
+    input logic [cif_resp_if.USER_WIDTH-1:0] strap_clp_axi_user,
+
+    // Access lock interface
+    input logic mcu_sram_fw_exec_region_lock,
+
+    // ECC Status
+    output logic sram_single_ecc_error,
+    output logic sram_double_ecc_error,
+
+
+    // Interface with SRAM
+    mci_mcu_sram_if.request mci_mcu_sram_req_if
+
+
+);
+localparam BITS_IN_BYTE = 8;
+localparam KB = 1024; // Bytes in KB
+
+localparam MCU_SRAM_SIZE_BYTES = MCU_SRAM_SIZE_KB * KB;
+localparam MCU_SRAM_DATA_W = mci_mcu_sram_req_if.DATA_WIDTH;
+localparam MCU_SRAM_DATA_W_BYTES = MCU_SRAM_DATA_W / BITS_IN_BYTE;
+localparam MCU_SRAM_ECC_DATA_W = mci_mcu_sram_req_if.ECC_WIDTH;
+localparam MCU_SRAM_DATA_AND_ECC_W = MCU_SRAM_DATA_W + MCU_SRAM_ECC_DATA_W;
+localparam MCU_SRAM_DEPTH = MCU_SRAM_SIZE_BYTES / MCU_SRAM_DATA_W_BYTES;
+localparam MCU_SRAM_ADDR_W = $clog2(MCU_SRAM_DEPTH);
+
+// Number of address bits needed on cif_req_if.addr to address the entire 
+// SRAM. AKA address scope
+localparam MCU_SRAM_CIF_ADDR_W = $clog2(MCU_SRAM_SIZE_BYTES);
+
+
+
+// Memory region request
+logic exec_region_match;
+logic exec_region_req;
+logic prot_region_req;
+
+// Momory region mapping
+logic [28:0]                    exec_region_base; // TODO: Report to status register?
+logic [28:0]                    exec_region_end_calc;  
+logic [28:0]                    exec_region_end;  // TODO: Report to status register?
+logic                           exec_region_overflow;
+// fw_sram_exec_region_size size is 16 bits so the max size 
+// the exec region can be is (0xFFF + 1) << 12 =  10_000_000
+// Which bit 28 set.
+logic [28:0] exec_region_size_bytes;
+
+
+
+// Filtering status
+logic exec_region_filter_success;
+logic exec_region_filter_error; 
+
+logic prot_region_filter_success;
+logic prot_region_filter_error; 
+
+// Agent request checks
+logic mcu_lsu_req;
+logic mcu_ifu_req;
+logic clp_req;
+
+// SRAM Read/Write request and phase signals
+logic mcu_sram_valid_req;
+logic mcu_sram_read_req;
+logic mcu_sram_write_req;
+logic sram_req_phase;
+logic sram_read_req_phase;
+logic sram_write_req_phase;
+logic sram_read_data_phase;
+
+// SRAM read/ecc
+logic sram_rd_ecc_en;
+logic [MCU_SRAM_DATA_W-1:0] sram_rdata;
+logic [MCU_SRAM_DATA_W-1:0] sram_rdata_cor;
+logic [MCU_SRAM_ECC_DATA_W-1:0] sram_rdata_ecc;
+
+///////////////////////////////////////////////
+// Calculate all properties about the SRAM 
+// based on the fw_sram_exec_region_size
+///////////////////////////////////////////////
+assign exec_region_base = '0;
+// 4KB = 2^12
+assign exec_region_size_bytes   = {13'b0, (fw_sram_exec_region_size + 16'b1)} << 12; 
+// Calculate final address based on the fw_sram_exec_region_size.
+assign exec_region_end_calc     = exec_region_base + exec_region_size_bytes - 1;
+// Check if there was overflow due to fw_sram_exec_region_size being larger than the entire
+// SRAM.
+assign exec_region_overflow  = |exec_region_end_calc[28:MCU_SRAM_CIF_ADDR_W];
+// If there was overflow set to the MCU SRAM size.
+// Otherwise take the calculated value
+assign exec_region_end          = exec_region_overflow ? (MCU_SRAM_SIZE_BYTES-1) : 
+                                    exec_region_end_calc;  
+
+
+
+
+///////////////////////////////////////////////
+// Determine if protected region or execution
+// region is being accessed
+///////////////////////////////////////////////
+
+// Detect if the address in the MCU_SRAM scope matches the exec region 
+// When determining the exec_region_end it must address overflow/over provision 
+// issues for this check to work.
+assign exec_region_match =  (cif_resp_if.req_data.addr[MCU_SRAM_CIF_ADDR_W-1:0] <= exec_region_end[MCU_SRAM_CIF_ADDR_W-1:0]);
+
+// Qualify the exec_region_match with DV to detect either exec or prot
+// region request
+assign exec_region_req = cif_resp_if.dv & exec_region_match;
+assign prot_region_req = cif_resp_if.dv & !exec_region_match; 
+
+
+///////////////////////////////////////////////
+// Determine if the user matches any of the  
+// previlaged users
+///////////////////////////////////////////////
+assign mcu_lsu_req = ~(|(cif_resp_if.req_data.user ^ strap_mcu_lsu_axi_user));
+assign mcu_ifu_req = ~(|(cif_resp_if.req_data.user ^ strap_mcu_ifu_axi_user));
+assign clp_req = ~(|(cif_resp_if.req_data.user ^ strap_clp_axi_user));
+
+///////////////////////////////////////////////
+// Protected data region access protection  
+///////////////////////////////////////////////
+
+// This logic will help in 2 areas:
+// 1. We can use these signals to block read or a write
+//    ever reaching the SRAM.
+// 2. Reads take 2 clock cycles. But we can use these signals
+//    to detect an illegal access and respond with an error 
+//    on the first clock cycle
+assign prot_region_filter_success = prot_region_req & mcu_lsu_req;
+assign prot_region_filter_error   = prot_region_req & ~prot_region_filter_success;
+
+
+///////////////////////////////////////////////
+// Execution data region access protection  
+///////////////////////////////////////////////
+
+// This logic will help in 2 areas:
+// 1. We can use these signals to block read or a write
+//    ever reaching the SRAM.
+// 2. Reads take 2 clock cycles. But we can use these signals
+//    to detect an illegal access and respond with an error 
+//    on the first clock cycle
+always_comb begin
+    exec_region_filter_success = '0;
+    exec_region_filter_error   = '0;
+    if (exec_region_req) begin
+        if (mcu_sram_fw_exec_region_lock) begin
+            exec_region_filter_success = (mcu_lsu_req | mcu_ifu_req);
+            exec_region_filter_error   = ~exec_region_filter_success;
+        end 
+        else begin
+            exec_region_filter_success = clp_req;
+            exec_region_filter_error   = ~exec_region_filter_success;
+        end
+    end
+end
+
+
+///////////////////////////////////////////////
+// Converting the CIF to memory request 
+///////////////////////////////////////////////
+
+
+//////////
+// Additional control signal
+//////////
+// CIF read or write request has successfully passed all filtering 
+// and the request needs to be sent to the SRAM
+assign mcu_sram_valid_req = exec_region_filter_success | prot_region_filter_success;
+
+// Detecting read vs write requests
+assign mcu_sram_read_req  = mcu_sram_valid_req & (~cif_resp_if.req_data.write);
+assign mcu_sram_write_req = mcu_sram_valid_req & cif_resp_if.req_data.write;
+
+
+// Reading the sram takes 2 clock cycles and write request only take
+// 1 clock cycles
+// 1 - req_phase: Request sent to SRAM to read an address
+// 2 - data_phase: Data is read back from the SRAM. Not needed for write requests
+assign sram_req_phase = mcu_sram_valid_req  & ~sram_read_data_phase; 
+
+assign sram_write_req_phase = sram_req_phase & mcu_sram_write_req;
+assign sram_read_req_phase = sram_req_phase & mcu_sram_write_req;
+
+always_ff @(posedge clk or negedge rst_b) begin
+    if(!rst_b) begin
+        sram_read_data_phase <= '0;
+    end
+    else begin
+        sram_read_data_phase <= (sram_req_phase & mcu_sram_read_req);
+    end
+
+end
+
+
+//////////
+// General Read/Write SRAM controls
+//////////
+
+// All these signals should only be asserted during the sram_req_phase
+// otherwise when we do reads that require 2 clock cycles we will
+// trigger a second read to the SRAM.
+
+// Either read or write we need to pass the address to the memory interface.
+// Must shift the address to account for sram being more than 1 byte wide 
+assign mci_mcu_sram_req_if.req.addr = sram_req_phase ? cif_resp_if.req_data.addr [MCU_SRAM_ADDR_W-1:2] : '0;
+
+// All requests assert CS
+assign mci_mcu_sram_req_if.req.cs = sram_req_phase;
+
+
+//////////
+// Write SRAM controls
+//////////
+
+// Only toggle WE if write request
+assign mci_mcu_sram_req_if.req.we    = sram_write_req_phase; 
+
+// Only passing write data to SRAM if write request.
+assign mci_mcu_sram_req_if.req.wdata.data = sram_write_req_phase ? cif_resp_if.req_data.wdata : '0;
+
+// From RISC-V core beh_lib.sv
+// 32-bit data width hardcoded
+// 7-bit ECC width hardcoded
+rvecc_encode ecc_encode (
+    .din    ( mci_mcu_sram_req_if.req.wdata.data),
+    .ecc_out( mci_mcu_sram_req_if.req.wdata.ecc )
+);
+
+
+//////////
+// Read SRAM controls
+//////////
+
+assign sram_rd_ecc_en = sram_read_req_phase;
+
+assign sram_rdata = mci_mcu_sram_req_if.resp.rdata.data;
+assign sram_rdata_ecc = mci_mcu_sram_req_if.resp.rdata.ecc;
+
+rvecc_decode ecc_decode (
+    .en              (sram_rd_ecc_en       ),
+    .sed_ded         ( 1'b0                ),    // 1 : means only detection
+    .din             (sram_rdata           ),
+    .ecc_in          (sram_rdata_ecc       ),
+    .dout            (sram_rdata_cor       ),
+    .ecc_out         (                     ), // Unused in today's design
+    .single_ecc_error(sram_single_ecc_error), // TODO use to flag write-back
+    .double_ecc_error(sram_double_ecc_error)  // TODO use to flag command error
+);
+
+// Only send data back if we are in the sram_read_data_phase. Assumptions made:
+// 1. We will only have sram_read_data_phase if a privilaged agent is doing the read
+// 2. If an ECC error is detected it is OK to send garbage data back.
+assign cif_resp_if.rdata = sram_read_data_phase ?  sram_rdata_cor : '0;
+
+///////////////////////////////////////////////
+// Hold response 
+///////////////////////////////////////////////
+
+// Only hold up the interface if we have a successful 
+// read request. Meaning the read request got through all
+// the protection filtering and is sent to the SRAM. 
+// We wait 1 clock cycle and then read data is back
+// from the sram
+assign cif_resp_if.hold = sram_read_req_phase; 
+
+
+///////////////////////////////////////////////
+// Error response 
+///////////////////////////////////////////////
+
+// Anytime an error is detected we pass it back on the interface.
+// All error sources in this module shall only assert when DV is asserted.
+// This logic is just an aggregate of the error sources and will not check
+// for DV.
+assign cif_resp_if.error = exec_region_filter_error | 
+                           prot_region_filter_error | 
+                           sram_double_ecc_error; // FIXME any other error conditions? 
+
+
+endmodule

--- a/src/mci/rtl/mci_mcu_sram_if.sv
+++ b/src/mci/rtl/mci_mcu_sram_if.sv
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Description:
+//      Signals for an SRAM interface with ECC
+//
+
+interface mci_mcu_sram_if #(parameter integer ADDR_WIDTH = 16, parameter integer DATA_WIDTH = 32, parameter integer ECC_WIDTH = 7) (input logic clk, input logic rst_b);
+
+    // SRAM data
+    typedef struct packed {
+        logic [ECC_WIDTH-1:0]   ecc;
+        logic [DATA_WIDTH-1:0]  data;
+    } sram_data_t;
+
+    // Request to sram
+    typedef struct packed {
+        logic cs;
+        logic we;
+        logic [ADDR_WIDTH-1:0] addr;
+        sram_data_t wdata;
+    } sram_req_t;
+
+    // Response from sram
+    typedef struct packed {
+        sram_data_t rdata;
+    } sram_resp_t;
+
+    sram_req_t req;
+
+    sram_resp_t resp;
+
+    // Requester interface
+    modport request (
+
+        // Request to SRAM
+        output  req,
+
+        // Response from SRAM
+        input   resp
+    );
+
+    // Response interface (typically on SRAM)
+    modport response (
+        // Request to SRAM
+        input  req,
+
+        // Response from SRAM
+        output   resp
+    );
+
+endinterface

--- a/src/mci/rtl/mci_pkg.sv
+++ b/src/mci/rtl/mci_pkg.sv
@@ -16,6 +16,10 @@
     `define MCI_PKG
 
 package mci_pkg;
+    localparam KB = 1024;
+    localparam KB_BASE0 = KB - 1;
+    localparam MB = KB * 1024;
+    localparam MB_BASE0 = MB - 1;
 
     // Assert reset for 10 cycles then deassert
     // to facilitate the hitless update
@@ -31,8 +35,8 @@ package mci_pkg;
         BOOT_WAIT_CPTRA    = 4'b0110,
         BOOT_CPTRA         = 4'b0111,
         BOOT_WAIT_UPDATE   = 4'b1000,
-        BOOT_RST_MCU       = 4'b1001,
+        BOOT_RST_MCU       = 4'b1001
     } mci_boot_fsm_state_e;
 
-endmodule
+endpackage
 `endif /*MCI_PKG*/

--- a/src/mci/rtl/mci_pkg.sv
+++ b/src/mci/rtl/mci_pkg.sv
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+`ifndef MCI_PKG
+    `define MCI_PKG
+
+package mci_pkg;
+
+    // Assert reset for 10 cycles then deassert
+    // to facilitate the hitless update
+    parameter MCI_MCU_UPDATE_RESET_CYLES = 10;
+
+    typedef enum logic [3:0] {
+        BOOT_IDLE          = 4'b0000,
+        BOOT_FABRIC        = 4'b0001,
+        BOOT_OTP_FC        = 4'b0010,
+        BOOT_LCC           = 4'b0011,
+        BOOT_MCU           = 4'b0100,
+        BOOT_PLL           = 4'b0101,
+        BOOT_WAIT_CPTRA    = 4'b0110,
+        BOOT_CPTRA         = 4'b0111,
+        BOOT_WAIT_UPDATE   = 4'b1000,
+        BOOT_RST_MCU       = 4'b1001,
+    } mci_boot_fsm_state_e;
+
+endmodule
+`endif /*MCI_PKG*/

--- a/src/mci/rtl/mci_reg.rdl
+++ b/src/mci/rtl/mci_reg.rdl
@@ -1,0 +1,518 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////
+// MCI Registers
+addrmap mci_reg {
+
+    ////////////////////////////////////////////////////////////////
+    // Properties
+    desc="Address map for Manufacturer Control Interface Block architectural registers";
+
+    addressing = regalign; // This is the default if not specified
+    lsb0 = true; // lsb0 property is implicit/default. See docs for
+                 // SystemRDL 2.0 sections 9.1 and 13.4
+    littleendian = true;
+
+    default hw = na;
+    signal {activelow; async; cpuif_reset; field_reset;} mci_rst_b;
+    signal {activelow; async;} mcu_rst_b; // uC reset only
+    signal {activelow; async;} mci_pwrgood;
+
+    //signal to indicate request origin
+    // TODO need these?
+    signal {} cptra_req;
+    signal {} mcu_req;
+
+    //defined fields by access type
+    // TODO
+    field rw_rw_sticky_hw { sw=rw; hw=rw; we=true; woclr = true; resetsignal = mci_pwrgood;}; //W1C            - used by HW ERROR regs
+    field rw_rw_sticky    { sw=rw; hw=rw; we=true; swmod = true; resetsignal = mci_pwrgood;}; //writes enabled - used by FW ERROR regs
+
+    ////////////////////////////////////////////////////////////////
+    // Registers
+
+    // ----------------------------------------
+    // ------------ IDENTIFICATION ------------
+    reg {
+        name = "Manufacturer Control Interface Capabilities";
+        desc = "Reports configuration and build options for MCI.
+                [br]Caliptra Access: RO
+                [br]MCU Access:      RO
+                [br]SoC Access:      RO";
+        field {desc = "Number of Mailboxes in MCI"; hw=w; sw=r;} NUM_MBOX[4];
+    } CAPABILITIES;
+    reg {
+        name = "MCI/MCU HW RevID";
+        desc = "HW revision ID for Manufacturer Control components (MCU & MCI) that matches the official
+                final release milestone of Caliptra Subsystem.
+                [br]Caliptra Access: RO
+                [br]MCU Access:      RO
+                [br]SOC Access:      RO";
+        field {desc = "Official release version. Bit field encoding is:
+                       [br][lb]15:12[rb] Major version
+                       [br][lb]11: 8[rb] Minor version
+                       [br][lb] 7: 0[rb] Patch version";
+               sw=r;} MC_GENERATION[16]=0x1000;
+        field {sw=r; hw=w; resetsignal = mci_rst_b;} SOC_STEPPING_ID[16]=0; // TODO
+    } HW_REV_ID;
+    reg {
+        name = "MCU FW RevID";
+        desc = "MCU FW revision ID
+                [br]Caliptra Access: RO
+                [br]MCU Access:      RW
+                [br]SOC Access:      RO";
+        field {sw=rw; swwe = mcu_req; resetsignal = mci_rst_b;} REV_ID[32]=0;
+    } FW_REV_ID[2];
+    reg {
+        name = "MCU HW Config";
+        desc = "MCU HW Configuration
+                [br]Caliptra Access: RO
+                [br]MCU Access:      RO
+                [br]SOC Access:      RO";
+        // No storage, i.e. no resetsignal
+        field {sw=r; hw=w;} RSVD_en;
+    } HW_CONFIG;
+
+    // ----------------------------------------
+    // ---------------- STATUS ----------------
+    reg {
+        name = "Boot Status";
+        desc = "Reports the boot status.
+                [br]Caliptra Access: RO
+                [br]MCU Access:      RW
+                [br]SOC Access:      RO
+                [br]TAP Access [in debug/manuf mode]: RO";
+        field {swwe = mcu_req; hw=r; resetsignal = mci_rst_b;} status[32]=0;
+    } BOOT_STATUS @0x20;
+    reg {
+        name = "Flow Status";
+        desc = "Reports the status of the firmware flows.
+                [br]Caliptra Access: RO
+                [br]MCU Access:      RW
+                [br]SOC Access:      RO";
+        field {desc="Generic Status";                                            sw=rw; swwe = mci_req; hw=r ; resetsignal = mci_rst_b;} status[24]=0;
+        field {desc="DEV ID CSR ready";                                          sw=r;                         /* no storage, no reset */} rsvd[3]=0;
+        field {desc="Boot FSM State";                                            sw=r;                  hw=w ; /* no storage, no reset */} boot_fsm_ps[5];
+    } FLOW_STATUS;
+    reg {
+        name = "Reset Reason";
+        desc = "Indicates to ROM the originating cause for the PC to be reset to 0.
+                Firmware Update Reset indicator is reset by the warm reset.
+                Warm Reset indicator is reset by the cold reset.
+                [br]Caliptra Access: RO
+                [br]MCU Access:      RO
+                [br]SOC Access:      RO";
+        field {desc = "FW update reset has been executed"; sw=r; hw=rw; we=true; resetsignal = mci_rst_b;  } FW_UPD_RESET=0;
+        field {desc = "Warm reset has been executed";      sw=r; hw=rw;          resetsignal = mci_pwrgood;} WARM_RESET=0;
+    } RESET_REASON;
+
+    // ----------------------------------------
+    // ---------------- ERROR -----------------
+    reg {
+        name = "Hardware Error Fatal";
+        desc = "Indicates fatal hardware error. Assertion of any bit in this
+                register results in the assertion of the SoC interrupt pin,
+                mci_error_fatal, unless that bit is masked using the internal
+                mask register. After the output interrupt is asserted, clearing
+                the bit in this register will not cause the interrupt to deassert.
+                Only an MCI reset will clear the fatal error interrupt.
+                [br]Caliptra Access: RW1C
+                [br]MCU Access:      RW1C
+                [br]SOC Access:      RW1C";
+        rw_rw_sticky_hw RSVD=1'b0;
+    } HW_ERROR_FATAL @0x40;
+    reg {
+        name = "Hardware Error Non-Fatal";
+        desc = "Indicates non-fatal hardware error. Assertion of any bit in this
+                register results in the assertion of the SoC interrupt pin,
+                mci_error_non_fatal, unless that bit is masked using the internal
+                mask register. After the output interrupt is asserted, any
+                change by firmware that results in all set non-fatal errors
+                being masked will immediately deassert the interrupt output. This means
+                that firmware may cause the mci_error_non_fatal signal to deassert by
+                writing to any of these registers, if the write results in all error
+                bits being cleared or masked:
+                [br][list]
+                [br] [*] HW_ERROR_NON_FATAL
+                [br] [*] FW_ERROR_NON_FATAL
+                [br] [*] hw_error_non_fatal_mask
+                [br] [*] fw_error_non_fatal_mask 
+                [/list]
+                [br]Caliptra Access: RW1C
+                [br]MCU Access:      RW1C
+                [br]SOC Access:      RW1C";
+        rw_rw_sticky_hw RSVD=1'b0;
+    } HW_ERROR_NON_FATAL;
+    reg {
+        name = "Firmware Error Fatal";
+        desc = "Indicates fatal firmware error. Assertion of any bit in this
+                register results in the assertion of the SoC interrupt pin,
+                mci_error_fatal, unless that bit is masked using the internal
+                mask register. After the output interrupt is asserted, clearing
+                the bit in this register will not cause the interrupt to deassert.
+                Only an MCI reset will clear the fatal error interrupt.
+                [br]Caliptra Access: RW
+                [br]MCU Access:      RW
+                [br]SOC Access:      RW";
+        rw_rw_sticky error_code[32]=0; 
+    } FW_ERROR_FATAL;
+    reg {
+        name = "Firmware Error Non-Fatal";
+        desc = "Indicates non-fatal firmware error. Assertion of any bit in this
+                register results in the assertion of the SoC interrupt pin,
+                mci_error_non_fatal, unless that bit is masked using the internal
+                mask register. After the output interrupt is asserted, any
+                change by firmware that results in all set non-fatal errors
+                being masked will immediately deassert the interrupt output. This means
+                that firmware may cause the mci_error_non_fatal signal to deassert by
+                writing to any of these registers, if the write results in all error
+                bits being cleared or masked:
+                [br][list]
+                [br] [*] HW_ERROR_NON_FATAL
+                [br] [*] FW_ERROR_NON_FATAL
+                [br] [*] hw_error_non_fatal_mask
+                [br] [*] fw_error_non_fatal_mask
+                [/list]
+                [br]Caliptra Access: RW
+                [br]MCU Access:      RW
+                [br]SOC Access:      RW";
+        rw_rw_sticky error_code[32]=0; 
+    } FW_ERROR_NON_FATAL;
+    reg {
+        name = "Hardware Error Encoding";
+        desc = "Encoded error value for hardware errors.
+                [br]Caliptra Access: RW
+                [br]SOC Access:      RW";
+         field {resetsignal = mci_pwrgood; hw=r;}error_code[32]=0; 
+    } HW_ERROR_ENC;
+    reg {
+        name = "Firmware Error Encoding";
+        desc = "Encoded error value for firmware errors.
+                [br]Caliptra Access: RW
+                [br]SOC Access:      RW";
+        field {resetsignal = mci_pwrgood; hw=r;} error_code[32]=0; 
+    } FW_ERROR_ENC;
+    reg {
+        name = "Firmware Extended Error Information";
+        desc = "Firmware Extended Error information for firmware errors.
+                [br]Caliptra Access: RW
+                [br]SOC Access:      RW";
+        field {resetsignal = mci_pwrgood; hw=r;} error_info[32]=0; 
+    } FW_EXTENDED_ERROR_INFO[8];
+
+    // TODO add FW/HW ERROR masks (like in Caliptra)?
+
+    // ----------------------------------------
+    // ----------------- WDT ------------------
+    //Timer1
+    reg {
+        name = "WDT Timer1 EN register";
+        desc = "Watchdog timer1 enable register
+                [br]Caliptra Access: RO
+                [br]MCU Access:      RW
+                [br]SoC Access:      RO";
+        field {desc = "WDT timer1 enable"; hw = r; sw = rw; swwe = mcu_req; resetsignal = mci_rst_b;} timer1_en = 1'b0;
+    } WDT_TIMER1_EN @0x80;
+
+    reg {
+        name = "WDT Timer1 CTRL register";
+        desc = "Watchdog timer1 control register
+                [br]Caliptra Access: RO
+                [br]MCU Access:      RW
+                [br]SOC Access:      RO";
+        field {desc = "WDT timer1 restart"; hw = r; sw = rw; swwe = mcu_req; resetsignal = mci_rst_b; singlepulse;} timer1_restart = 1'b0;
+    } WDT_TIMER1_CTRL;
+
+    reg {
+        name = "WDT Timer1 Timeout Period register";
+        desc = "Watchdog timer1 timeout register
+                [br]Caliptra Access: RO
+                [br]MCU Access:      RW
+                [br]SOC Access:      RO";
+        field {desc = "WDT timer1 timeout period"; hw = r; sw = rw; swwe = mcu_req; resetsignal = mci_rst_b;} timer1_timeout_period[32] = 32'hFFFFFFFF;
+    } WDT_TIMER1_TIMEOUT_PERIOD[2]; // This reflects WDT_TIMEOUT_PERIOD_NUM_DWORDS in FIXME _pkg
+
+    //Timer2
+    reg {
+        name = "WDT Timer2 EN register";
+        desc = "Watchdog timer2 enable register. Note: Setting this to 1 will disable the default cascaded mode and will have both timers count independently.
+                [br]Caliptra Access: RO
+                [br]MCU Access:      RW
+                [br]SOC Access:      RO ";
+        field {desc = "WDT timer2 enable"; hw = r; sw = rw; swwe = mcu_req; resetsignal = mci_rst_b;} timer2_en = 1'b0;
+    } WDT_TIMER2_EN;
+
+    reg {
+        name = "WDT Timer2 CTRL register";
+        desc = "Watchdog timer2 control register
+                [br]Caliptra Access: RO
+                [br]MCU Access:      RW
+                [br]SOC Access:      RO";
+        field {desc = "WDT timer2 restart"; hw = r; sw = rw; swwe = mcu_req; resetsignal = mci_rst_b; singlepulse;} timer2_restart = 1'b0;
+    } WDT_TIMER2_CTRL;
+
+    reg {
+        name = "WDT Timer2 Timeout Period register";
+        desc = "Watchdog timer2 timeout register
+                [br]Caliptra Access: RO
+                [br]MCU Access:      RW
+                [br]SOC Access:      RO";
+        field {desc = "WDT timer2 timeout period"; hw = r; sw = rw; swwe = mcu_req; resetsignal = mci_rst_b;} timer2_timeout_period[32] = 32'hFFFFFFFF;
+    } WDT_TIMER2_TIMEOUT_PERIOD[2]; //This reflects WDT_TIMEOUT_PERIOD_NUM_DWORDS in FIXME _pkg
+
+    //Status
+    reg {
+        name = "WDT STATUS register";
+        desc = "Watchdog timer status register
+                [br]Caliptra Access: RO
+                [br]MCU Access:      RW
+                [br]SOC Access:      RO";
+        field {desc = "Timer1 timed out, timer2 enabled"; hw = rw; sw = rw; swwe = mcu_req; resetsignal = mci_rst_b;} t1_timeout = 1'b0;
+        field {desc = "Timer2 timed out"; hw = rw; sw = rw; swwe = mcu_req; resetsignal = mci_rst_b;} t2_timeout = 1'b0;
+    } WDT_STATUS;
+
+    // Req
+    reg {
+        name = "WDT1 Config";
+        desc = "SOC provided count in cycles for WDT1 timeout.
+                [br]Caliptra Access: RW
+                [br]MCU Access:      RW
+                [br]SOC Access:      RW";
+        field {sw=rw; hw=na; resetsignal = mci_pwrgood;} TIMEOUT[32]=0;
+    } WDT_CFG[2] @0xB0;
+
+    // ----------------------------------------
+    // ---------------- TIMER -----------------
+    reg {
+        name = "Timer Config";
+        desc = "Provides the clock period of the system clock.
+                Used to standardize the RISC-V Standard MTIME count register.
+                Clock Period is indicated as an integer number of picoseconds.";
+        field {desc = "Period in (ps)"; sw=rw; hw=na; resetsignal = mci_pwrgood;} clk_period[32] = 32'h0;
+    } MCU_TIMER_CONFIG @0xC0;
+    reg {
+        name = "MCU Clock Gating En";
+         // TODO
+    } MCU_CLK_GATING_EN;
+
+    reg {
+        name = "mtime low";
+        desc = "RISC-V Standard Machine-mode Time Counter, lower 32-bits.
+                [br]Frequency of counter is indicated in MCU_TIMER_CONFIG.clk_period.
+                [br]Caliptra Access: RO
+                [br]MCU Access:      RW
+                [br]SOC Access:      RO";
+        field {desc = "Counter Low" ; sw = rw; precedence = sw; swmod = true; hw = r; swwe = mcu_req; counter = true; incrvalue = 1; overflow = true; resetsignal = mci_pwrgood;} count_l[32] = 32'h0;
+    } MCU_RV_MTIME_L;
+
+    reg {
+        name = "mtime high";
+        desc = "RISC-V Standard Machine-mode Time Counter, upper 32-bits.
+                [br]Frequency of counter is indicated in MCU_TIMER_CONFIG.clk_period.
+                [br]Caliptra Access: RO
+                [br]MCU Access:      RW
+                [br]SOC Access:      RO";
+        field {desc = "Counter High"; sw = rw; precedence = sw; swmod = true; hw = r; swwe = mcu_req; counter = true; incrvalue = 1;                  resetsignal = mci_pwrgood;} count_h[32] = 32'h0;
+    } MCU_RV_MTIME_H;
+
+    reg {
+        name = "mtimecmp low";
+        desc = "RISC-V Standard Machine-mode Time Counter Compare Value, lower 32-bits.
+                [br]Caliptra Access: RO
+                [br]MCU Access:      RW
+                [br]SOC Access:      RO";
+        field {desc = "Count Compare Low" ; sw = rw; hw = r; swwe = mcu_req; resetsignal = mci_pwrgood;} compare_l[32] = 32'h0;
+    } MCU_RV_MTIMECMP_L;
+
+    reg {
+        name = "mtimecmp high";
+        desc = "RISC-V Standard Machine-mode Time Counter Compare Value, upper 32-bits.
+                [br]Caliptra Access: RO
+                [br]MCU Access:      RW
+                [br]SOC Access:      RO";
+        field {desc = "Count Compare High"; sw = rw; hw = r; swwe = mcu_req; resetsignal = mci_pwrgood;} compare_h[32] = 32'h0;
+    } MCU_RV_MTIMECMP_H;
+
+
+    // ----------------------------------------
+    // ----------- RESET/BOOT MGMT ------------
+    reg {
+        name = "Reset Request";
+        desc = "Used by Caliptra to request an MCU reset to facilitate firmware updates.
+                Reset request is the first step in a handshake protocol between Caliptra and
+                the MCU before the MCU is reset and executes updated firmware.
+                [br]Caliptra Access: RW
+                [br]MCU Access:      RO
+                [br]SOC Access:      RO";
+        field { desc = "Request. Writable by Caliptra. Causes MCU interrupt to assert."; sw=rw; hw=r; hwclr=true; swwe=cptra_req; resetsignal=mci_rst_b; } req=1'b0;
+        field { desc = "Clear. Writable by Caliptra. On set, this bit autoclears, RESET_REQUEST.req clears, and MCU reset deasserts."; sw=rw; hw=r; swwe=cptra_req; onwrite=woset; singlepulse=true; resetsignal=mci_rst_b; } clr=1'b0;
+    } RESET_REQUEST @0x100;
+    reg {
+        name = "Reset Ack";
+        desc = "Used by MCU to acknowledge reset request by Caliptra for a firmware update.
+                If RESET_REQUEST.req is set, a write by MCU to set the ack bit causes the MCU reset to assert.
+                [br]Caliptra Access: RO
+                [br]MCU Access:      RW
+                [br]SOC Access:      RO";
+        field { desc = "Ack. Writable by MCU. Causes MCU reset to assert (if RESET_REQUEST.req is also set)"; sw=rw; hw=r; hwclr=true; swwe=mcu_req; resetsignal=mci_rst_b; } ack=1'b0;
+    } RESET_ACK;
+// TODO finish desc for these
+    reg {
+        field { desc="fixme";} go=1'b0;
+    } CALIPTRA_BOOT_GO;
+    reg {
+        field {sw=r; hw=w; } id;
+    } CALIPTRA_AXI_ID;
+    reg {
+        name = "Firmware SRAM Exec Region Size";
+        desc = "Dynamic size assignment for the region of sram that contains executable instructions for MCU.";
+        field { desc="Size (in multiples of 4KiB)"; sw=rw; swwe=true; } size;
+    } FW_SRAM_EXEC_REGION_SIZE;
+    reg {
+        name = "Runtime Lock";
+        desc = "Writable only by Caliptra, only when already at 0. (W1S, cleared only by MCU FW Update reset).
+                [br]With a value of 0, only the Caliptra AXI ID is allowed to access the Updateable Execution SRAM region in the MCU.
+                [br]Writing 1 to this register enables the MCU LSU and IFU AXI IDs to access the Updateable Execution SRAM Region.
+                AXI IDs are provided as integration parameter/macro to MCU. 
+                Observing a value of 1 in this register (after exiting a reset) also indicates to MCU ROM that it may perform context switch to RT image.";
+        field {/*TODO*/ sw=rw;} lock=0;
+    } RUNTIME_LOCK;
+
+    // TODO nmi_vector, reset_vector
+
+    // ----------------------------------------
+    // ------------ AxUSER CONFIG -------------
+    reg { field {sw=rw;/*TODO*/ } id[32]=0;} MBOX0_VALID_AXI_ID [5] @0x180;
+    reg { field {sw=rw;/*TODO*/ } lock=0;  } MBOX0_VALID_AXI_ID_LOCK [5] @0x1A0;
+    reg { field {sw=rw;/*TODO*/ } id[32]=0;} MBOX1_VALID_AXI_ID [5] @0x1C0;
+    reg { field {sw=rw;/*TODO*/ } lock=0;  } MBOX1_VALID_AXI_ID_LOCK [5] @0x1E0;
+
+    // ----------------------------------------
+    // ------------ DEBUG/GENERIC -------------
+    reg { field {/*TODO*/sw=r;  hw=w;} wires[32]=32'b0; } GENERIC_INPUT_WIRES[2] @0x400;
+    reg { field {/*TODO*/sw=rw; hw=r;} wires[32]=32'b0; } GENERIC_OUTPUT_WIRES[2];
+    reg { } DEBUG_IN; // i.e. stdin
+    reg { } DEBUG_OUT; // i.e. stdout
+
+    reg {
+        name = "FUSE Write Done";
+        desc = "Set to indicate that all fuse registers have been populated in MCI.
+                Locks fuse registers from further modification.
+                Sticky until cold reset once set.
+                [br]Caliptra Access: RO
+                [br]MCU Access:      RW
+                [br]SOC Access:      RO";
+        field {sw = rw; hw=r; swwel; swmod=true; resetsignal = mci_pwrgood;} done=1'h0; // TODO
+    } FUSE_WR_DONE @0x440;
+
+    reg {
+        name = "Production Debug Unlock PK HASH";
+        desc = "Production Debug Unlock PK HASH. Initialized from strap inputs, overwritable by MCU until FUSE_WR_DONE is set.
+                Once FUSE_WR_DONE is set value persists until cold reset.
+                [br]Caliptra Access: RO
+                [br]MCU Access:      RW
+                [br]SOC Access:      RO";
+        field {sw = rw; hw = rw; we; swwel; resetsignal = mci_pwrgood;} hash[32]=32'h0; // TODO
+    } PROD_DEBUG_UNLOCK_PK_HASH_REG[8][12] @0x480;
+
+    // ----------------------------------------
+    // ----- DATA_VAULT/SCRATCH/RESERVED ------
+    reg {
+        name = "STICKY DATA VAULT CTRL";
+        desc = "Controls for the Sticky Data Vault Entries (cleared on cold reset)
+                [br]Caliptra Access: RO
+                [br]MCU Access:      RW
+                [br]SOC Access:      RO";
+        field {desc="Lock writes to this entry. Writes will be suppressed when locked.";
+               sw=rw; swwel=true; hw=r; resetsignal=mci_pwrgood;} lock_entry=0; //TODO Shoud reflect STICKY_DV_NUM_ENTRIES from dv_defines_pkg.sv
+    } STICKY_DATA_VAULT_CTRL[10] @0x800;
+
+    reg {
+        name = "STICKY DATA VAULT ENTRY";
+        desc = "Sticky Data Vault Entry (cleared on cold reset). Lockable.
+                [br]Caliptra Access: RO
+                [br]MCU Access:      RW
+                [br]SOC Access:      RO";
+        field {desc="DataVault Entry (cleared on cold reset)"; sw=rw; hw=na; swwel=true; resetsignal = mci_pwrgood;};
+    } STICKY_DATA_VAULT_ENTRY[10][12];//TODO Shoud reflect STICKY_DV_NUM_ENTRIES and DV_NUM_DWORDS from dv_defines_pkg.sv
+
+    reg {
+        name = "DATA VAULT CTRL";
+        desc = "Controls for the Data Vault Entries (cleared on warm reset)
+                [br]Caliptra Access: RO
+                [br]MCU Access:      RW
+                [br]SOC Access:      RO";
+        field {desc="Lock writes to this entry. Writes will be suppressed when locked.";
+               sw=rw; swwel=true; hw=r; resetsignal=mcu_rst_b;} lock_entry=0; // TODO Shoud reflect DV_NUM_ENTRIES and DV_NUM_DWORDS from dv_defines_pkg.sv
+    } DATA_VAULT_CTRL[10];// CAREFUL with the address extensions
+
+    reg {
+        name = "DATA VAULT ENTRY";
+        desc = "Data Vault Entry (cleared on cold reset). Lockable.
+                [br]Caliptra Access: RO
+                [br]MCU Access:      RW
+                [br]SOC Access:      RO";
+        field {desc="DataVault Entry (cleared on cold reset)"; sw=rw; hw=na; swwel=true; resetsignal = mci_pwrgood;};
+    } DATA_VAULT_ENTRY[10][12];// TODO Shoud reflect DV_NUM_ENTRIES and DV_NUM_DWORDS from dv_defines_pkg.sv
+
+    reg {
+        name = "STICKY LOCKABLE SCRATCH REG CTRL";
+        desc = "Sticky Scratch Register Controls (cleared on cold reset)
+                [br]Caliptra Access: RO
+                [br]MCU Access:      RW
+                [br]SOC Access:      RO";
+        field {desc="Lock writes to the Scratch registers. Writes will be suppressed when locked.";
+               sw=rw; swwel=true; hw=r; resetsignal=mci_pwrgood;} lock_entry=0;
+    } STICKY_LOCKABLE_SCRATCH_REG_CTRL[8]; // TODO should reflect STICKY_LOCKQ_SCRATCH_NUM_ENTRIES
+
+    reg {
+        name = "STICKY LOCKABLE SCRATCH REG";
+        desc = "Sticky Scratch Register Entries (cleared on cold reset)
+                [br]Caliptra Access: RO
+                [br]MCU Access:      RW
+                [br]SOC Access:      RO";
+        field {sw=rw; swwel=true; hw=na; resetsignal=mci_pwrgood;} data[32]=0;
+    } STICKY_LOCKABLE_SCRATCH_REG[8]; // TODO should reflect STICKY_LOCKQ_SCRATCH_NUM_ENTRIES
+
+    reg {
+        name = "LOCKABLE SCRATCH REG CTRL";
+        desc = "Scratch Register Controls (cleared on warm reset)
+                [br]Caliptra Access: RO
+                [br]MCU Access:      RW
+                [br]SOC Access:      RO";
+        field {desc="Lock writes to the Scratch registers. Writes will be suppressed when locked.";
+               sw=rw; swwel=true; hw=r; resetsignal=mcu_rst_b;} lock_entry=0;
+    } LOCKABLE_SCRATCH_REG_CTRL[10]; // TODO Shoud reflect LOCK_SCRATCH_NUM_ENTRIES from dv_defines_pkg.sv & CAREFUL with the address extensions
+
+    reg {
+        name = "LOCKABLE SCRATCH REG";
+        desc = "Scratch Register Entry (cleared on cold reset)
+                [br]Caliptra Access: RO
+                [br]MCU Access:      RW
+                [br]SOC Access:      RO";
+        field {sw=rw; swwel=true; hw=na; resetsignal=mci_pwrgood;} data[32]=0;
+    } LOCKABLE_SCRATCH_REG[10]; // TODO Shoud reflect LOCK_SCRATCH_NUM_ENTRIES from dv_defines_pkg.sv
+
+    reg {
+        name = "NON STICKY GENERIC SCRATCH REG";
+        desc = "
+                [br]Caliptra Access: RO
+                [br]MCU Access:      RW
+                [br]SOC Access:      RO";
+        field {sw=rw; hw=na; resetsignal=mci_rst_b;} data[32]=0; // FIXME mcu_rst_b instead?
+    } NON_STICKY_GENERIC_SCRATCH_REG[8]; // TODO Shoud reflect NONSTICKY_SCRATCH_NUM_ENTRIES from dv_defines_pkg.sv & CAREFUL with the address extensions
+
+    // ------------ TODO interrupts @0x1000 ------------
+};

--- a/src/mci/rtl/mci_top.sv
+++ b/src/mci/rtl/mci_top.sv
@@ -12,6 +12,100 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module mci_top();
+module mci_top 
+    #(
+    parameter MCU_SRAM_SIZE_KB = 1024 // FIXME - write assertion ensuring this size 
+                                      // is compatible with the MCU SRAM IF parameters
+    )
+    (
+    input logic clk,
+
+    // MCI Resets
+    input logic mci_rst_b,
+
+    // MCI AXI Interface
+    axi_if.w_sub s_axi_w_if,
+    axi_if.r_sub s_axi_r_if,
+    
+    // MCU SRAM Interface
+    mci_mcu_sram_if.request mci_mcu_sram_req_if 
+
+    );
+
+    localparam AXI_ADDR_WIDTH = s_axi_w_if.AW;
+    localparam AXI_DATA_WIDTH = s_axi_w_if.DW;
+    localparam AXI_USER_WIDTH = s_axi_w_if.UW;
+    localparam AXI_ID_WIDTH   = s_axi_w_if.IW;
+
+
+// Caliptra internal fabric interface for MCU SRAM 
+// Address width is set to AXI_ADDR_WIDTH and MCU SRAM
+// will mask out upper bits that are "don't care"
+cif_if #(
+    .ADDR_WIDTH(AXI_ADDR_WIDTH)
+    ,.DATA_WIDTH(AXI_DATA_WIDTH)
+    ,.ID_WIDTH(AXI_ID_WIDTH)
+    ,.USER_WIDTH(AXI_USER_WIDTH)
+) mcu_sram_req_if(
+    .clk, 
+    .rst_b(mci_rst_b));
+
+//AXI Interface
+//This module contains the logic for interfacing with the SoC over the AXI Interface
+//The SoC sends read and write requests using AXI Protocol
+//This wrapper decodes that protocol, collapses the full-duplex protocol to
+// simplex, and issues requests to the MIC decode block
+mci_axi_sub_top #( // FIXME: Should SUB and MAIN be under same AXI_TOP module?
+    .MCU_SRAM_SIZE_KB(MCU_SRAM_SIZE_KB),
+    .MBOX0_SIZE_KB (4),     // FIXME
+    .MBOX1_SIZE_KB  (4)     // FIXME
+) i_mci_axi_sub_top (
+    // MCI clk
+    .clk  (clk     ),
+
+    // MCI Resets
+    .rst_b(mci_rst_b), // FIXME: Need to sync reset
+
+    // AXI INF
+    .s_axi_w_if(s_axi_w_if),
+    .s_axi_r_if(s_axi_r_if),
+
+    // MCU SRAM Interface
+    .mcu_sram_req_if( mcu_sram_req_if.request )
+);
+
+
+// MCU SRAM
+// Translates requests from the AXI SUB and sends them to the MCU SRAM.
+mci_mcu_sram_ctrl #(
+    .MCU_SRAM_SIZE_KB(MCU_SRAM_SIZE_KB)
+) i_mci_mcu_sram_ctrl (
+    // MCI clk
+    .clk    (clk),
+
+    // MCI Resets
+    .rst_b (mci_rst_b), // FIXME: Need to sync reset
+
+    // Interface
+    .fw_sram_exec_region_size('0), // FIXME
+
+    // Caliptra internal fabric response interface
+    .cif_resp_if (mcu_sram_req_if.response),
+
+    // AXI users
+    .strap_mcu_lsu_axi_user('0),   // FIXME
+    .strap_mcu_ifu_axi_user('0),   // FIXME
+    .strap_clp_axi_user('0),   // FIXME
+
+    // Access lock interface
+    .mcu_sram_fw_exec_region_lock('0),  // FIXME
+
+    // ECC Status
+    .sram_single_ecc_error(),   // FIXME
+    .sram_double_ecc_error(),   // FIXME
+
+    // Interface with SRAM
+    .mci_mcu_sram_req_if(mci_mcu_sram_req_if)
+);
 
 endmodule

--- a/src/mci/rtl/mci_top.sv
+++ b/src/mci/rtl/mci_top.sv
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module mci_top();
+
+endmodule


### PR DESCRIPTION
- Add MCI to caliptra-ss repo
- Created a top which has an AXI SUB and MCU SRAM control logic
- Some of the MCU SRAM control signals are left tied off due to MCI CSRs not in yet.
- Data path from MCI Top -> AXI SUB -> MCU SRAM is complete but unverified
- This is not integrated into caliptra-ss integration model
