### PR TITLE
changed alert interface

### DIFF
--- a/src/caliptra_ss_lc_ctrl/rtl/caliptra_ss_lc_ctrl.sv
+++ b/src/caliptra_ss_lc_ctrl/rtl/caliptra_ss_lc_ctrl.sv
@@ -35,7 +35,9 @@ module caliptra_ss_lc_ctrl
   // Life cycle controller clock
   input                                              clk_i,
   input                                              rst_ni,
-  input                                              Allow_RMA_on_PPD,
+  input                                              Allow_RMA_on_PPD, // Note: Addded another condition to RMA transition with Physical presence Detect
+                                                                       // This is GPIO strap pin. This pin should be high until LC completes its state
+                                                                       // transition to RMA.  
   // Clock for KMAC interface
   // input                                              clk_kmac_i,
   // input                                              rst_kmac_ni,
@@ -61,16 +63,38 @@ module caliptra_ss_lc_ctrl
   // This bypasses the clock inverter inside the JTAG TAP for scanmmode.
   input                                              scan_rst_ni,
   input  caliptra_prim_mubi_pkg::mubi4_t                      scanmode_i,
+
+
   // Alert outputs.
-  input  caliptra_prim_alert_pkg::alert_rx_t [NumAlerts-1:0]  alert_rx_i,
-  output caliptra_prim_alert_pkg::alert_tx_t [NumAlerts-1:0]  alert_tx_o,
-  // Escalation inputs (severity 1 and 2).
-  // These need not be synchronized since the alert handler is
-  // in the same clock domain as the LC controller.
-  input  caliptra_prim_esc_pkg::esc_rx_t                      esc_scrap_state0_tx_i,
-  output caliptra_prim_esc_pkg::esc_tx_t                      esc_scrap_state0_rx_o,
-  input  caliptra_prim_esc_pkg::esc_rx_t                      esc_scrap_state1_tx_i,
-  output caliptra_prim_esc_pkg::esc_tx_t                      esc_scrap_state1_rx_o,
+  //----------------------------------------------------------------------------------
+  // NOTE: Caliptra-SS removed these differential alert sender signals. Caliptra-SS 
+  // uses "alerts" signal  instead of these pair signal set. SoC should take action if 
+  // there is at leastone of the error signals: fatal_bus_integ_error_q,
+  // fatal_state_error_q, or fatal_prog_error_q
+
+  output [NumAlerts-1:0] alerts,
+  // input  caliptra_prim_alert_pkg::alert_rx_t [NumAlerts-1:0]  alert_rx_i,
+  // output caliptra_prim_alert_pkg::alert_tx_t [NumAlerts-1:0]  alert_tx_o,
+
+  //-----------------------------------------------------------------------------------
+
+  //----------------------------------------------------------------------------------
+  // NOTE: Caliptra-SS removed these differential escalation signals. Instead of
+  // generating esc_scrap_state0 and esc_scrap_state1 with prim_esc_receiver, 
+  // Caliptra-SS delivers these signals to LC_CTRL
+
+  input esc_scrap_state0,
+  input esc_scrap_state1,
+  // // Escalation inputs (severity 1 and 2).
+  // // These need not be synchronized since the alert handler is
+  // // in the same clock domain as the LC controller.
+  // input  caliptra_prim_esc_pkg::esc_rx_t                      esc_scrap_state0_tx_i,
+  // output caliptra_prim_esc_pkg::esc_tx_t                      esc_scrap_state0_rx_o,
+  // input  caliptra_prim_esc_pkg::esc_rx_t                      esc_scrap_state1_tx_i,
+  // output caliptra_prim_esc_pkg::esc_tx_t                      esc_scrap_state1_rx_o,
+  //-----------------------------------------------------------------------------------
+
+
   // Power manager interface (inputs are synced to lifecycle clock domain).
   input  pwrmgr_pkg::pwr_caliptra_ss_lc_req_t                    pwr_caliptra_ss_lc_i,
   output pwrmgr_pkg::pwr_caliptra_ss_lc_rsp_t                    pwr_caliptra_ss_lc_o,
@@ -661,7 +685,7 @@ module caliptra_ss_lc_ctrl
   // Alert Sender //
   //////////////////
 
-  logic [NumAlerts-1:0] alerts;
+  // logic [NumAlerts-1:0] alerts;
   logic [NumAlerts-1:0] alert_test;
   logic [NumAlerts-1:0] tap_dmi_alert_test;
 
@@ -689,22 +713,30 @@ module caliptra_ss_lc_ctrl
     tap_dmi_reg2hw.alert_test.fatal_prog_error.qe
   };
 
-  for (genvar k = 0; k < NumAlerts; k++) begin : gen_alert_tx
-    caliptra_prim_alert_sender #(
-      .AsyncOn(AlertAsyncOn[k]),
-      .IsFatal(1)
-    ) u_prim_alert_sender (
-      .clk_i,
-      .rst_ni,
-      .alert_test_i  ( alert_test[k] |
-                       tap_dmi_alert_test[k] ),
-      .alert_req_i   ( alerts[k]             ),
-      .alert_ack_o   (                       ),
-      .alert_state_o (                       ),
-      .alert_rx_i    ( alert_rx_i[k]         ),
-      .alert_tx_o    ( alert_tx_o[k]         )
-    );
-  end
+// ------------------------Removing Alert sender module----------------------------
+// NOTE: Caliptra-SS wires out alerts[k] signals and makes them output of LC_CTRL
+// This action also removes the functionallity of alert test that can be done with
+// alert_test and tap_dmi_alert_test.
+  
+  // for (genvar k = 0; k < NumAlerts; k++) begin : gen_alert_tx
+  //   caliptra_prim_alert_sender #(
+  //     .AsyncOn(AlertAsyncOn[k]),
+  //     .IsFatal(1)
+  //   ) u_prim_alert_sender (
+  //     .clk_i,
+  //     .rst_ni,
+  //     .alert_test_i  ( alert_test[k] |
+  //                      tap_dmi_alert_test[k] ),
+  //     .alert_req_i   ( alerts[k]             ),
+  //     .alert_ack_o   (                       ),
+  //     .alert_state_o (                       ),
+  //     .alert_rx_i    ( alert_rx_i[k]         ),
+  //     .alert_tx_o    ( alert_tx_o[k]         )
+  //   );
+  // end
+
+//------------------------------------------------------------------------------------
+
 
   ///////////////////////////////
   // KMAC design Instance
@@ -765,47 +797,51 @@ module caliptra_ss_lc_ctrl
     .entropy_i          ('0)
   );
 
+//----------------------------------------------------------------------------------
+// NOTE: Caliptra-SS removed these differential esc_receiver signals and module. 
 
-  //////////////////////////
-  // Escalation Receivers //
-  //////////////////////////
+  // //////////////////////////
+  // // Escalation Receivers //
+  // //////////////////////////
 
-  // SEC_CM: MAIN.FSM.GLOBAL_ESC
-  // We still have two escalation receivers here for historical reasons.
-  // The two actions "wipe secrets" and "scrap lifecycle state" have been
-  // combined in order to simplify both DV and the design, as otherwise
-  // this separation of very intertwined actions would have caused too many
-  // unnecessary corner cases. The escalation receivers are now redundant and
-  // trigger both actions at once.
+  // // SEC_CM: MAIN.FSM.GLOBAL_ESC
+  // // We still have two escalation receivers here for historical reasons.
+  // // The two actions "wipe secrets" and "scrap lifecycle state" have been
+  // // combined in order to simplify both DV and the design, as otherwise
+  // // this separation of very intertwined actions would have caused too many
+  // // unnecessary corner cases. The escalation receivers are now redundant and
+  // // trigger both actions at once.
 
-  // This escalation action moves the life cycle
-  // state into a temporary "SCRAP" state named "ESCALATE",
-  // and asserts the caliptra_ss_lc_escalate_en life cycle control signal.
-  logic esc_scrap_state0;
-  caliptra_prim_esc_receiver #(
-    .N_ESC_SEV   (alert_handler_reg_pkg::N_ESC_SEV),
-    .PING_CNT_DW (alert_handler_reg_pkg::PING_CNT_DW)
-  ) u_prim_esc_receiver0 (
-    .clk_i,
-    .rst_ni,
-    .esc_req_o (esc_scrap_state0),
-    .esc_rx_o  (esc_scrap_state0_rx_o),
-    .esc_tx_i  (esc_scrap_state0_tx_i)
-  );
+  // // This escalation action moves the life cycle
+  // // state into a temporary "SCRAP" state named "ESCALATE",
+  // // and asserts the caliptra_ss_lc_escalate_en life cycle control signal.
+  // logic esc_scrap_state0;
+  // caliptra_prim_esc_receiver #(
+  //   .N_ESC_SEV   (alert_handler_reg_pkg::N_ESC_SEV),
+  //   .PING_CNT_DW (alert_handler_reg_pkg::PING_CNT_DW)
+  // ) u_prim_esc_receiver0 (
+  //   .clk_i,
+  //   .rst_ni,
+  //   .esc_req_o (esc_scrap_state0),
+  //   .esc_rx_o  (esc_scrap_state0_rx_o),
+  //   .esc_tx_i  (esc_scrap_state0_tx_i)
+  // );
 
-  // This escalation action moves the life cycle
-  // state into a temporary "SCRAP" state named "ESCALATE".
-  logic esc_scrap_state1;
-  caliptra_prim_esc_receiver #(
-    .N_ESC_SEV   (alert_handler_reg_pkg::N_ESC_SEV),
-    .PING_CNT_DW (alert_handler_reg_pkg::PING_CNT_DW)
-  ) u_prim_esc_receiver1 (
-    .clk_i,
-    .rst_ni,
-    .esc_req_o (esc_scrap_state1),
-    .esc_rx_o  (esc_scrap_state1_rx_o),
-    .esc_tx_i  (esc_scrap_state1_tx_i)
-  );
+  // // This escalation action moves the life cycle
+  // // state into a temporary "SCRAP" state named "ESCALATE".
+  // logic esc_scrap_state1;
+  // caliptra_prim_esc_receiver #(
+  //   .N_ESC_SEV   (alert_handler_reg_pkg::N_ESC_SEV),
+  //   .PING_CNT_DW (alert_handler_reg_pkg::PING_CNT_DW)
+  // ) u_prim_esc_receiver1 (
+  //   .clk_i,
+  //   .rst_ni,
+  //   .esc_req_o (esc_scrap_state1),
+  //   .esc_rx_o  (esc_scrap_state1_rx_o),
+  //   .esc_tx_i  (esc_scrap_state1_tx_i)
+  // );
+//----------------------------------------------------------------------------------
+
 
   ////////////////////////////
   // Synchronization of IOs //
@@ -944,7 +980,7 @@ module caliptra_ss_lc_ctrl
 
   `CALIPTRA_ASSERT_KNOWN(RegsTlOKnown,           regs_tl_o                  )
   `CALIPTRA_ASSERT_KNOWN(DmiTlOKnown,            dmi_tl_o                   )
-  `CALIPTRA_ASSERT_KNOWN(AlertTxKnown_A,         alert_tx_o                 )
+  //`CALIPTRA_ASSERT_KNOWN(AlertTxKnown_A,         alert_tx_o                 ) // -> NOTE: Removed since we do not use this port anymore
   `CALIPTRA_ASSERT_KNOWN(PwrLcKnown_A,           pwr_caliptra_ss_lc_o                   )
   `CALIPTRA_ASSERT_KNOWN(LcOtpProgramKnown_A,    caliptra_ss_lc_otp_program_o           )
   `CALIPTRA_ASSERT_KNOWN(LcOtpTokenKnown_A,      kmac_data_o                )
@@ -965,29 +1001,80 @@ module caliptra_ss_lc_ctrl
   `CALIPTRA_ASSERT_KNOWN(LcFlashRmaReqKnown_A,   caliptra_ss_lc_flash_rma_req_o         )
   `CALIPTRA_ASSERT_KNOWN(LcKeymgrDiv_A,          caliptra_ss_lc_keymgr_div_o            )
 
+  
+  
+// ------------------------------------------------------------------------------------------
+// NOTE: Assertions have been updated since Caliptra-SS changed the alert and escalation
+// signals
+  
+  caliptra_prim_alert_pkg::alert_tx_t state_alert;
+  caliptra_prim_alert_pkg::alert_tx_t program_alert;
+
+  always_comb begin
+    if (fatal_state_error_q) begin
+      state_alert.alert_p = 1'b1;
+      state_alert.alert_n = 1'b0;
+    end else begin
+      state_alert.alert_p = 1'b0;
+      state_alert.alert_n = 1'b1;
+    end
+    if (fatal_prog_error_q) begin
+      program_alert.alert_p = 1'b1;
+      program_alert.alert_n = 1'b0;
+    end else begin
+      program_alert.alert_p = 1'b0;
+      program_alert.alert_n = 1'b1;
+    end
+  end
+
   // Alert assertions for sparse FSMs.
+  // `CALIPTRA_ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(CtrlLcFsmCheck_A,
+  //     u_caliptra_ss_lc_ctrl_fsm.u_fsm_state_regs, alert_tx_o[1])
   `CALIPTRA_ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(CtrlLcFsmCheck_A,
-      u_caliptra_ss_lc_ctrl_fsm.u_fsm_state_regs, alert_tx_o[1])
+      u_caliptra_ss_lc_ctrl_fsm.u_fsm_state_regs, state_alert)
+  // `CALIPTRA_ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(CtrlLcStateCheck_A,
+  //     u_caliptra_ss_lc_ctrl_fsm.u_state_regs, alert_tx_o[1],
+  //     !$past(otp_caliptra_ss_lc_data_i.valid) ||
+  //     u_caliptra_ss_lc_ctrl_fsm.fsm_state_q inside {ResetSt, EscalateSt, PostTransSt, InvalidSt, ScrapSt} ||
+  //     u_caliptra_ss_lc_ctrl_fsm.esc_scrap_state0_i ||
+  //     u_caliptra_ss_lc_ctrl_fsm.esc_scrap_state1_i)
   `CALIPTRA_ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(CtrlLcStateCheck_A,
-      u_caliptra_ss_lc_ctrl_fsm.u_state_regs, alert_tx_o[1],
+      u_caliptra_ss_lc_ctrl_fsm.u_state_regs, state_alert,
       !$past(otp_caliptra_ss_lc_data_i.valid) ||
       u_caliptra_ss_lc_ctrl_fsm.fsm_state_q inside {ResetSt, EscalateSt, PostTransSt, InvalidSt, ScrapSt} ||
       u_caliptra_ss_lc_ctrl_fsm.esc_scrap_state0_i ||
       u_caliptra_ss_lc_ctrl_fsm.esc_scrap_state1_i)
+  // `CALIPTRA_ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(CtrlLcCntCheck_A,
+  //     u_caliptra_ss_lc_ctrl_fsm.u_cnt_regs, alert_tx_o[1],
+  //      !$past(otp_caliptra_ss_lc_data_i.valid) ||
+  //     u_caliptra_ss_lc_ctrl_fsm.fsm_state_q inside {ResetSt, EscalateSt, PostTransSt, InvalidSt, ScrapSt} ||
+  //     u_caliptra_ss_lc_ctrl_fsm.esc_scrap_state0_i ||
+  //     u_caliptra_ss_lc_ctrl_fsm.esc_scrap_state1_i)
   `CALIPTRA_ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(CtrlLcCntCheck_A,
-      u_caliptra_ss_lc_ctrl_fsm.u_cnt_regs, alert_tx_o[1],
+      u_caliptra_ss_lc_ctrl_fsm.u_cnt_regs, state_alert,
        !$past(otp_caliptra_ss_lc_data_i.valid) ||
       u_caliptra_ss_lc_ctrl_fsm.fsm_state_q inside {ResetSt, EscalateSt, PostTransSt, InvalidSt, ScrapSt} ||
       u_caliptra_ss_lc_ctrl_fsm.esc_scrap_state0_i ||
       u_caliptra_ss_lc_ctrl_fsm.esc_scrap_state1_i)
- `CALIPTRA_ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(CtrlKmacIfFsmCheck_A,
-      u_caliptra_ss_lc_ctrl_kmac_if.u_state_regs, alert_tx_o[1],
+  //  `CALIPTRA_ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(CtrlKmacIfFsmCheck_A,
+  //       u_caliptra_ss_lc_ctrl_kmac_if.u_state_regs, alert_tx_o[1],
+  //       u_caliptra_ss_lc_ctrl_fsm.fsm_state_q inside {EscalateSt} ||
+  //       u_caliptra_ss_lc_ctrl_fsm.esc_scrap_state0_i ||
+  //       u_caliptra_ss_lc_ctrl_fsm.esc_scrap_state1_i)
+  `CALIPTRA_ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(CtrlKmacIfFsmCheck_A,
+      u_caliptra_ss_lc_ctrl_kmac_if.u_state_regs, state_alert,
       u_caliptra_ss_lc_ctrl_fsm.fsm_state_q inside {EscalateSt} ||
       u_caliptra_ss_lc_ctrl_fsm.esc_scrap_state0_i ||
       u_caliptra_ss_lc_ctrl_fsm.esc_scrap_state1_i)
 
   // Alert assertions for reg_we onehot check
-  `CALIPTRA_ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegsWeOnehotCheck_A, u_reg_regs, alert_tx_o[2])
+  // `CALIPTRA_ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegsWeOnehotCheck_A, u_reg_regs, alert_tx_o[2])
+  // `CALIPTRA_ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(TapDmiWeOnehotCheck_A,
+  //                                                u_reg_tap_dmi, alert_tx_o[2], 0)
+  `CALIPTRA_ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(RegsWeOnehotCheck_A, u_reg_regs, program_alert)
   `CALIPTRA_ASSERT_PRIM_REG_WE_ONEHOT_ERROR_TRIGGER_ALERT(TapDmiWeOnehotCheck_A,
-                                                 u_reg_tap_dmi, alert_tx_o[2], 0)
+                                                 u_reg_tap_dmi, program_alert, 0)
+
+// ------------------------------------------------------------------------------------------
+  
 endmodule : caliptra_ss_lc_ctrl

--- a/src/caliptra_ss_lc_ctrl/rtl/caliptra_ss_lc_ctrl_fsm.sv
+++ b/src/caliptra_ss_lc_ctrl/rtl/caliptra_ss_lc_ctrl_fsm.sv
@@ -464,7 +464,7 @@ module caliptra_ss_lc_ctrl_fsm
       // Flash RMA state. Note that we check the flash response again
       // two times later below.
       FlashRmaSt: begin
-        if (trans_target_i == {DecLcStateNumRep{DecLcStRma}} && Allow_RMA_on_PPD) begin
+        if (trans_target_i == {DecLcStateNumRep{DecLcStRma}} && Allow_RMA_on_PPD) begin // Note: Addded another condition to RMA transition 
           caliptra_ss_lc_flash_rma_req = On;
           if (caliptra_ss_lc_tx_test_true_strict(caliptra_ss_lc_flash_rma_ack_buf[0])) begin
             fsm_state_d = TokenCheck0St;
@@ -491,7 +491,7 @@ module caliptra_ss_lc_ctrl_fsm
               (trans_target_i == {DecLcStateNumRep{DecLcStRma}} &&
                caliptra_ss_lc_tx_test_true_strict(caliptra_ss_lc_flash_rma_req_o) &&
                caliptra_ss_lc_tx_test_true_strict(caliptra_ss_lc_flash_rma_ack_buf[1])
-               && Allow_RMA_on_PPD)) begin
+               && Allow_RMA_on_PPD)) begin // Note: Addded another condition to RMA transition 
             if (hashed_token_i == hashed_token_mux &&
                 !token_hash_err_i &&
                 &hashed_token_valid_mux) begin
@@ -532,7 +532,7 @@ module caliptra_ss_lc_ctrl_fsm
                       (caliptra_ss_lc_flash_rma_req_o != Off || caliptra_ss_lc_flash_rma_ack_buf[2] != Off)) ||
                      (trans_target_i == {DecLcStateNumRep{DecLcStRma}} &&
                       (caliptra_ss_lc_flash_rma_req_o != On || caliptra_ss_lc_flash_rma_ack_buf[2] != On)
-                      && Allow_RMA_on_PPD)) begin
+                      && Allow_RMA_on_PPD)) begin // Note: Addded another condition to RMA transition 
           fsm_state_d = PostTransSt;
           flash_rma_error_o = 1'b1;
         end else if (otp_prog_ack_i) begin

--- a/src/caliptra_ss_lc_ctrl/rtl/caliptra_ss_lc_ctrl_pkg.sv
+++ b/src/caliptra_ss_lc_ctrl/rtl/caliptra_ss_lc_ctrl_pkg.sv
@@ -334,10 +334,10 @@ package caliptra_ss_lc_ctrl_pkg;
     // DEV
     ZeroTokenIdx,          // -> SCRAP
     RmaTokenIdx,           // -> RMA
-    // NOTE:
+    // ============== Enabling state trans from DEV to PROD ==============================
+    // NOTE: This is how we enable from DEV to PROD. The commented line shows the old version
+    // Next line shows Caliptra-SS's update
     // {19{InvalidTokenIdx}}, // -> TEST_LOCKED0-6, TEST_UNLOCKED0-7, DEV, PROD, PROD_END
-
-    // ============== This is how we enable from DEV to PROD ==============================
     InvalidTokenIdx, // -> PROD_END
     TestExitTokenIdx, // -> PROD
     {17{InvalidTokenIdx}}, // -> TEST_LOCKED0-6, TEST_UNLOCKED0-7, DEV

--- a/src/caliptra_ss_lc_ctrl/rtl/caliptra_ss_lc_ctrl_pkg.sv
+++ b/src/caliptra_ss_lc_ctrl/rtl/caliptra_ss_lc_ctrl_pkg.sv
@@ -334,7 +334,7 @@ package caliptra_ss_lc_ctrl_pkg;
     // DEV
     ZeroTokenIdx,          // -> SCRAP
     RmaTokenIdx,           // -> RMA
-
+    // NOTE:
     // {19{InvalidTokenIdx}}, // -> TEST_LOCKED0-6, TEST_UNLOCKED0-7, DEV, PROD, PROD_END
 
     // ============== This is how we enable from DEV to PROD ==============================

--- a/src/caliptra_ss_lc_ctrl/rtl/caliptra_ss_lc_ctrl_state_pkg.sv
+++ b/src/caliptra_ss_lc_ctrl/rtl/caliptra_ss_lc_ctrl_state_pkg.sv
@@ -283,7 +283,10 @@ package caliptra_ss_lc_ctrl_state_pkg;
   // are not supported for virtual interfaces by Excelium yet
   // https://github.com/lowRISC/opentitan/issues/8884 (Cadence issue: cds_46570160)
   // The enumeration types caliptra_ss_lc_state_e and caliptra_ss_lc_cnt_e are still ok in other circumstances
-
+  // NOTE: Caliptra-SS required the following change in this decoding:
+  // LcStProd          = {XX, XX, XX, XX, A15 -> B15, XX, ...} This allows LC to switch from DEV to PROD
+  // LcStProdEnd       = {XX, XX, XX, A16->B16, A15 -> B15, XX, ...} This allows LC to switch from DEV to PROD_END or PROD to PROD_END
+  // However, PROD_END can branch only to SCARP and nothing else
   typedef logic [LcStateWidth-1:0] caliptra_ss_lc_state_t;
   typedef enum caliptra_ss_lc_state_t {
     LcStRaw           = {ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO},

--- a/src/caliptra_ss_lc_ctrl/rtl/caliptra_ss_lc_ctrl_state_pkg.sv
+++ b/src/caliptra_ss_lc_ctrl/rtl/caliptra_ss_lc_ctrl_state_pkg.sv
@@ -287,6 +287,7 @@ package caliptra_ss_lc_ctrl_state_pkg;
   // LcStProd          = {XX, XX, XX, XX, A15 -> B15, XX, ...} This allows LC to switch from DEV to PROD
   // LcStProdEnd       = {XX, XX, XX, A16->B16, A15 -> B15, XX, ...} This allows LC to switch from DEV to PROD_END or PROD to PROD_END
   // However, PROD_END can branch only to SCARP and nothing else
+  // Note that the DEV state is being reused as MANUF state
   typedef logic [LcStateWidth-1:0] caliptra_ss_lc_state_t;
   typedef enum caliptra_ss_lc_state_t {
     LcStRaw           = {ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO, ZRO},

--- a/src/integration/testbench/caliptra_ss_lc_ctrl_bfm.sv
+++ b/src/integration/testbench/caliptra_ss_lc_ctrl_bfm.sv
@@ -45,19 +45,16 @@ module caliptra_ss_lc_ctrl_bfm
     output caliptra_prim_mubi_pkg::mubi4_t caliptra_ss_lc_ctrl_scanmode_i,
 
     // Alert Handler Interface
-    output caliptra_prim_alert_pkg::alert_rx_t [NumAlerts-1:0] caliptra_ss_lc_ctrl_alert_rx,
-    input  caliptra_prim_alert_pkg::alert_tx_t [NumAlerts-1:0] caliptra_ss_lc_ctrl_alert_tx,
+    input [caliptra_ss_lc_ctrl_reg_pkg::NumAlerts-1:0] lc_alerts_o,
+
+    // Escalation State Interface
+    output  esc_scrap_state0,
+    output  esc_scrap_state1,
+
 
     // OTP Hack
     output otp_ctrl_pkg::otp_caliptra_ss_lc_data_t   otp_caliptra_ss_lc_data_o,
     input otp_ctrl_pkg::otp_caliptra_ss_lc_data_t   from_otp_caliptra_ss_lc_data_i,
-
-    // Escape State Interface
-    output  caliptra_prim_esc_pkg::esc_rx_t esc_scrap_state0_tx_i,
-    input caliptra_prim_esc_pkg::esc_tx_t esc_scrap_state0_rx_o,
-    output  caliptra_prim_esc_pkg::esc_rx_t esc_scrap_state1_tx_i,
-    input caliptra_prim_esc_pkg::esc_tx_t esc_scrap_state1_rx_o,
-
     // Clock manager interface
     input  caliptra_ss_lc_ctrl_pkg::caliptra_ss_lc_tx_t caliptra_ss_lc_clk_byp_req_o,
     output caliptra_ss_lc_ctrl_pkg::caliptra_ss_lc_tx_t caliptra_ss_lc_clk_byp_ack_i
@@ -83,11 +80,7 @@ module caliptra_ss_lc_ctrl_bfm
     // Default values
     assign caliptra_ss_lc_ctrl_dmi_tl_h2d = tlul_pkg::TL_H2D_DEFAULT;
     assign caliptra_ss_lc_ctrl_scanmode_i = caliptra_prim_mubi_pkg::MuBi4False;
-    assign caliptra_ss_lc_ctrl_alert_rx = '{default: caliptra_prim_alert_pkg::ALERT_RX_DEFAULT};
-    assign esc_scrap_state0_tx_i.resp_p = 1'b0;
-    assign esc_scrap_state0_tx_i.resp_n = 1'b1;
-    assign esc_scrap_state1_tx_i.resp_p = 1'b0;
-    assign esc_scrap_state1_tx_i.resp_n = 1'b1;
+    
 
     //OTP assignments
     assign otp_caliptra_ss_lc_data_o.valid = from_otp_caliptra_ss_lc_data_i.valid;
@@ -102,6 +95,9 @@ module caliptra_ss_lc_ctrl_bfm
     assign otp_caliptra_ss_lc_data_o.rma_token = 128'h3852_305b_aecf_5ff1_d5c1_d25f_6db9_058d;
 
     assign from_bfm_caliptra_ss_lc_flash_rma_ack = (to_bfm_caliptra_ss_lc_flash_rma_req_o==3'h5) ? 8'h55 : 8'hAA;
+
+    assign esc_scrap_state0 = (|lc_alerts_o)? 1'b1: 1'b0;
+    assign esc_scrap_state1 = (|lc_alerts_o)? 1'b1: 1'b0;
 
 
     // TODO: This is used for keeping RMA strap to a desired value

--- a/src/integration/testbench/caliptra_ss_top.sv
+++ b/src/integration/testbench/caliptra_ss_top.sv
@@ -1925,23 +1925,7 @@ module caliptra_ss_top
     logic [$bits(caliptra_prim_mubi_pkg::mubi4_t)-1:0] caliptra_ss_lc_ctrl_scanmode_i_tb;
     assign caliptra_ss_lc_ctrl_scanmode_i_tb = caliptra_prim_mubi_pkg::mubi4_t'(u_caliptra_ss_lc_ctrl_bfm.caliptra_ss_lc_ctrl_scanmode_i);
 
-    // Alert Handler Interface
-    logic [$bits(caliptra_prim_alert_pkg::alert_rx_t)-1:0] [caliptra_ss_lc_ctrl_reg_pkg::NumAlerts-1:0] caliptra_ss_lc_ctrl_alert_rx_tb;
-    assign caliptra_ss_lc_ctrl_alert_rx_tb = caliptra_prim_alert_pkg::alert_rx_t'(u_caliptra_ss_lc_ctrl_bfm.caliptra_ss_lc_ctrl_alert_rx);
-    logic [$bits(caliptra_prim_alert_pkg::alert_tx_t)-1:0] [caliptra_ss_lc_ctrl_reg_pkg::NumAlerts-1:0] caliptra_ss_lc_ctrl_alert_tx_tb;
-    assign caliptra_ss_lc_ctrl_alert_tx_tb = caliptra_prim_alert_pkg::alert_tx_t'(u_caliptra_ss_lc_ctrl.alert_tx_o);
-    
-    // Escape State Interface
-    logic [$bits(caliptra_prim_esc_pkg::esc_rx_t)-1:0] esc_scrap_state0_tx_tb;
-    logic [$bits(caliptra_prim_esc_pkg::esc_tx_t)-1:0] esc_scrap_state0_rx_tb;
-    logic [$bits(caliptra_prim_esc_pkg::esc_rx_t)-1:0] esc_scrap_state1_tx_tb;
-    logic [$bits(caliptra_prim_esc_pkg::esc_tx_t)-1:0] esc_scrap_state1_rx_tb;
-
-    assign esc_scrap_state0_tx_tb = caliptra_prim_esc_pkg::esc_rx_t'(u_caliptra_ss_lc_ctrl_bfm.esc_scrap_state0_tx_i);
-    assign esc_scrap_state0_rx_tb = caliptra_prim_esc_pkg::esc_tx_t'(u_caliptra_ss_lc_ctrl.esc_scrap_state0_rx_o);
-    assign esc_scrap_state1_tx_tb = caliptra_prim_esc_pkg::esc_rx_t'(u_caliptra_ss_lc_ctrl_bfm.esc_scrap_state1_tx_i);
-    assign esc_scrap_state1_rx_tb = caliptra_prim_esc_pkg::esc_tx_t'(u_caliptra_ss_lc_ctrl.esc_scrap_state1_rx_o);
-    //--------------------------------------------------------------------------------------------
+   
 
 
     //--------------------------------------------------------------------------------------------
@@ -2020,7 +2004,9 @@ module caliptra_ss_top
     logic [3:0]  to_bfm_caliptra_ss_lc_flash_rma_req_o;
     assign to_bfm_caliptra_ss_lc_flash_rma_req_o = caliptra_ss_lc_ctrl_pkg::caliptra_ss_lc_tx_t'(u_caliptra_ss_lc_ctrl.caliptra_ss_lc_flash_rma_req_o);
 
-    
+    logic [caliptra_ss_lc_ctrl_reg_pkg::NumAlerts-1:0] lc_alerts_o;
+    logic esc_scrap_state0;
+    logic esc_scrap_state1;
 
     caliptra_ss_lc_ctrl_bfm u_caliptra_ss_lc_ctrl_bfm (
         .clk(core_clk),
@@ -2043,18 +2029,15 @@ module caliptra_ss_top
         .caliptra_ss_lc_ctrl_scanmode_i(),
 
         // Alert Handler Interface
-        .caliptra_ss_lc_ctrl_alert_rx(),
-        .caliptra_ss_lc_ctrl_alert_tx(caliptra_prim_alert_pkg::alert_tx_t'(caliptra_ss_lc_ctrl_alert_tx_tb)),
+        .lc_alerts_o(lc_alerts_o),
+
+        // Escalation State Interface
+        .esc_scrap_state0(esc_scrap_state0),
+        .esc_scrap_state1(esc_scrap_state1),
 
         // OTP hack
         .otp_caliptra_ss_lc_data_o(),
         .from_otp_caliptra_ss_lc_data_i(otp_ctrl_pkg::otp_caliptra_ss_lc_data_t'(u_otp_ctrl.otp_caliptra_ss_lc_data_o)),
-
-        // Escape State Interface
-        .esc_scrap_state0_tx_i(),
-        .esc_scrap_state0_rx_o(caliptra_prim_esc_pkg::esc_tx_t'(esc_scrap_state0_rx_tb)),
-        .esc_scrap_state1_tx_i(),
-        .esc_scrap_state1_rx_o(caliptra_prim_esc_pkg::esc_tx_t'(esc_scrap_state1_rx_tb)),
 
         // Power manager interface
         .pwr_caliptra_ss_lc_i(),
@@ -2102,12 +2085,15 @@ module caliptra_ss_top
             .scanmode_i(caliptra_prim_mubi_pkg::mubi4_t'(caliptra_ss_lc_ctrl_scanmode_i_tb)),
 
             // Alert Handler Interface
-            .alert_rx_i(caliptra_prim_alert_pkg::alert_rx_t'(caliptra_ss_lc_ctrl_alert_rx_tb)),
-            .alert_tx_o(),
-            .esc_scrap_state0_tx_i(caliptra_prim_esc_pkg::esc_rx_t'(esc_scrap_state0_tx_tb)),
-            .esc_scrap_state0_rx_o(),
-            .esc_scrap_state1_tx_i(caliptra_prim_esc_pkg::esc_rx_t'(esc_scrap_state1_tx_tb)),
-            .esc_scrap_state1_rx_o(),
+            // .alert_rx_i(caliptra_prim_alert_pkg::alert_rx_t'(caliptra_ss_lc_ctrl_alert_rx_tb)),
+            // .alert_tx_o(),
+            // .esc_scrap_state0_tx_i(caliptra_prim_esc_pkg::esc_rx_t'(esc_scrap_state0_tx_tb)),
+            // .esc_scrap_state0_rx_o(),
+            // .esc_scrap_state1_tx_i(caliptra_prim_esc_pkg::esc_rx_t'(esc_scrap_state1_tx_tb)),
+            // .esc_scrap_state1_rx_o(),
+            .alerts(lc_alerts_o),
+            .esc_scrap_state0(esc_scrap_state0),
+            .esc_scrap_state1(esc_scrap_state1),
 
 
             .pwr_caliptra_ss_lc_i(pwrmgr_pkg::pwr_caliptra_ss_lc_req_t'(pwr_caliptra_ss_lc_i_tb)),


### PR DESCRIPTION
Added comments for the previous pull request that includes the following changes:

- Added RAM strap to lc_bfm and lc_ctrl_fsm
- Added a triggering mechanism to reset and power init by reading LCC's HW_revision registers. It will be replaced later on with MCI
- Added "caliptra_ss_lc_ctrl_st_trans" C test that performs the following state transitions: RAW_to_TESTUNLOCK0, TESTUNLOCK0_to_DEV, DEV_to_RMA
- Hard-coded Fuse controller's broadcasted tokens in order to test LCC without going through the token provisioning phase such as: assign otp_caliptra_ss_lc_data_o.test_tokens_valid = caliptra_ss_lc_tx_t'(On);
- Added MANUF to PROD state transition

Updated the alert interface