### PR TITLE
instantiating mailboxes into mci

### DIFF
--- a/src/mci/config/compile.yml
+++ b/src/mci/config/compile.yml
@@ -41,4 +41,21 @@ targets:
     waiver_files:
       - $MSFT_REPO_ROOT/src/integration/config/design_lint/sglint_waivers
     tops: [mci_top]
-
+---
+provides: [mci_top_tb]
+schema_version: 2.4.0
+requires:
+  - mci_top
+targets:
+  tb:
+    directories:
+      - $COMPILE_ROOT/tb
+    files:
+      - $COMPILE_ROOT/tb/mci_top_tb.sv
+    tops: [mci_top_tb]
+global:
+  tool:
+    vcs:
+      default:
+        - '-assert svaext'
+        - '-noinherit_timescale=1ns/1ps'

--- a/src/mci/rtl/mci_axi_sub_decode.sv
+++ b/src/mci/rtl/mci_axi_sub_decode.sv
@@ -20,12 +20,10 @@
 module mci_axi_sub_decode 
     import mci_pkg::*;
     import mci_reg_pkg::*;
+    import mbox_csr_pkg::*;
     #(
     // Configurable memory blocks
     parameter MCU_SRAM_SIZE_KB = 1024,
-    parameter MBOX0_SIZE_KB    = 4, // KB
-    parameter MBOX1_SIZE_KB    = 4, // KB
-
 
     ///////////////////////////////////////////////////////////
     // MCI Memory Map
@@ -34,9 +32,9 @@ module mci_axi_sub_decode
     localparam MCI_REG_START_ADDR    = 32'h0000_0000,
     localparam MCI_REG_END_ADDR      = MCI_REG_START_ADDR + (MCI_REG_SIZE_BYTES) - 1,
     localparam MBOX0_START_ADDR      = 32'h0008_0000,
-    localparam MBOX0_END_ADDR        = MBOX0_START_ADDR + (MBOX0_SIZE_KB * KB) - 1,
-    localparam MBOX1_START_ADDR      = MBOX0_END_ADDR + 32'h0000_0001, // FIXME: Do we want B2B
-    localparam MBOX1_END_ADDR        = MBOX1_START_ADDR + (MBOX1_SIZE_KB * KB) - 1,
+    localparam MBOX0_END_ADDR        = MBOX0_START_ADDR + ((32'h0000_0001 << MBOX_CSR_ADDR_WIDTH) - 1),
+    localparam MBOX1_START_ADDR      = 32'h0009_0000,
+    localparam MBOX1_END_ADDR        = MBOX1_START_ADDR + ((32'h0000_0001 << MBOX_CSR_ADDR_WIDTH) - 1),
     localparam MCU_SRAM_START_ADDR   = 32'h0020_0000,
     localparam MCU_SRAM_END_ADDR     = MCU_SRAM_START_ADDR + (MCU_SRAM_SIZE_KB * KB) - 1 
         

--- a/src/mci/rtl/mci_axi_sub_decode.sv
+++ b/src/mci/rtl/mci_axi_sub_decode.sv
@@ -162,7 +162,7 @@ always_comb soc_resp_if.hold =  (soc_mcu_sram_gnt & (~soc_mcu_sram_gnt | mcu_sra
 ///////////////////////////////////////////////////////////
 
 // Missed all destinations 
-always_comb soc_req_miss = soc_resp_if.dv & ~(soc_mcu_sram_gnt | soc_mci_reg_gnt);
+always_comb soc_req_miss = soc_resp_if.dv & ~(soc_mcu_sram_gnt | soc_mci_reg_gnt | soc_mci_mbox0_gnt | soc_mci_mbox1_gnt);
 
 // Error for SOC
 always_comb soc_resp_if.error = (soc_mcu_sram_gnt  & mcu_sram_req_if.error)  |

--- a/src/mci/rtl/mci_axi_sub_top.sv
+++ b/src/mci/rtl/mci_axi_sub_top.sv
@@ -34,16 +34,16 @@ module mci_axi_sub_top
     axi_if.w_sub s_axi_w_if,
     axi_if.r_sub s_axi_r_if,
 
-    // MCU SRAM Interface
+    // MCI reg Interface
     cif_if.request  mci_reg_req_if,
 
     // MCU SRAM Interface
     cif_if.request  mcu_sram_req_if,
 
-    // MCU SRAM Interface
+    // Mbox0 SRAM Interface
     cif_if.request  mci_mbox0_req_if,
 
-    // MCU SRAM Interface
+    // Mbox1 SRAM Interface
     cif_if.request  mci_mbox1_req_if,
 
 

--- a/src/mci/rtl/mci_axi_sub_top.sv
+++ b/src/mci/rtl/mci_axi_sub_top.sv
@@ -20,9 +20,7 @@
 
 module mci_axi_sub_top 
     #(
-    parameter MCU_SRAM_SIZE_KB  = 1024,
-    parameter MBOX0_SIZE_KB    = 4,
-    parameter MBOX1_SIZE_KB    = 4
+    parameter MCU_SRAM_SIZE_KB  = 1024
     )
     (
     input logic clk,
@@ -125,9 +123,7 @@ assign soc_resp_if.req_data.size = '0; // FIXME unused?
 //This wrapper decodes that protocol, collapses the full-duplex protocol to
 // simplex, and issues requests to the MIC decode block
 mci_axi_sub_decode #(
-    .MCU_SRAM_SIZE_KB   (MCU_SRAM_SIZE_KB),
-    .MBOX0_SIZE_KB   (MBOX0_SIZE_KB),
-    .MBOX1_SIZE_KB   (MBOX1_SIZE_KB)
+    .MCU_SRAM_SIZE_KB   (MCU_SRAM_SIZE_KB)
 ) i_mci_axi_sub_decode (
     //SOC inf
     .soc_resp_if        (soc_resp_if.response),

--- a/src/mci/rtl/mci_axi_sub_top.sv
+++ b/src/mci/rtl/mci_axi_sub_top.sv
@@ -64,10 +64,10 @@ module mci_axi_sub_top
 
     );
 
-localparam AXI_ADDR_WIDTH = 32;//s_axi_w_if.AW;
-localparam AXI_DATA_WIDTH = 32;//s_axi_w_if.DW;
-localparam AXI_USER_WIDTH = 32;//s_axi_w_if.UW;
-localparam AXI_ID_WIDTH   = 8;//s_axi_w_if.IW;
+localparam AXI_ADDR_WIDTH = s_axi_w_if.AW;
+localparam AXI_DATA_WIDTH = s_axi_w_if.DW;
+localparam AXI_USER_WIDTH = s_axi_w_if.UW;
+localparam AXI_ID_WIDTH   = s_axi_w_if.IW;
 
 // Interface between axi_sub and mci decoder
 cif_if #(

--- a/src/mci/rtl/mci_axi_sub_top.sv
+++ b/src/mci/rtl/mci_axi_sub_top.sv
@@ -40,6 +40,12 @@ module mci_axi_sub_top
     // MCU SRAM Interface
     cif_if.request  mcu_sram_req_if,
 
+    // MCU SRAM Interface
+    cif_if.request  mci_mbox0_req_if,
+
+    // MCU SRAM Interface
+    cif_if.request  mci_mbox1_req_if,
+
 
     // Privileged requests 
     output logic mcu_lsu_req,
@@ -58,10 +64,10 @@ module mci_axi_sub_top
 
     );
 
-localparam AXI_ADDR_WIDTH = s_axi_w_if.AW;
-localparam AXI_DATA_WIDTH = s_axi_w_if.DW;
-localparam AXI_USER_WIDTH = s_axi_w_if.UW;
-localparam AXI_ID_WIDTH   = s_axi_w_if.IW;
+localparam AXI_ADDR_WIDTH = 32;//s_axi_w_if.AW;
+localparam AXI_DATA_WIDTH = 32;//s_axi_w_if.DW;
+localparam AXI_USER_WIDTH = 32;//s_axi_w_if.UW;
+localparam AXI_ID_WIDTH   = 8;//s_axi_w_if.IW;
 
 // Interface between axi_sub and mci decoder
 cif_if #(
@@ -131,7 +137,13 @@ mci_axi_sub_decode #(
 
     //MCU SRAM inf
     .mcu_sram_req_if,
-    
+
+    //MCI Mbox0
+    .mci_mbox0_req_if,
+
+    //MCI Mbox1
+    .mci_mbox1_req_if,
+
     // Privileged requests 
     .mcu_lsu_req,
     .mcu_ifu_req,

--- a/src/mci/rtl/mci_mcu_sram_ctrl.sv
+++ b/src/mci/rtl/mci_mcu_sram_ctrl.sv
@@ -71,9 +71,9 @@ localparam BITS_IN_BYTE = 8;
 localparam KB = 1024; // Bytes in KB
 
 localparam MCU_SRAM_SIZE_BYTES = MCU_SRAM_SIZE_KB * KB;
-localparam MCU_SRAM_DATA_W = mci_mcu_sram_req_if.DATA_WIDTH;
+localparam MCU_SRAM_DATA_W = 32;//mci_mcu_sram_req_if.DATA_WIDTH; FIXME
 localparam MCU_SRAM_DATA_W_BYTES = MCU_SRAM_DATA_W / BITS_IN_BYTE;
-localparam MCU_SRAM_ECC_DATA_W = mci_mcu_sram_req_if.ECC_WIDTH;
+localparam MCU_SRAM_ECC_DATA_W = 7;//mci_mcu_sram_req_if.ECC_WIDTH; FIXME
 localparam MCU_SRAM_DATA_AND_ECC_W = MCU_SRAM_DATA_W + MCU_SRAM_ECC_DATA_W;
 localparam MCU_SRAM_DEPTH = MCU_SRAM_SIZE_BYTES / MCU_SRAM_DATA_W_BYTES;
 localparam MCU_SRAM_ADDR_W = $clog2(MCU_SRAM_DEPTH);

--- a/src/mci/rtl/mci_mcu_sram_ctrl.sv
+++ b/src/mci/rtl/mci_mcu_sram_ctrl.sv
@@ -71,9 +71,9 @@ localparam BITS_IN_BYTE = 8;
 localparam KB = 1024; // Bytes in KB
 
 localparam MCU_SRAM_SIZE_BYTES = MCU_SRAM_SIZE_KB * KB;
-localparam MCU_SRAM_DATA_W = 32;//mci_mcu_sram_req_if.DATA_WIDTH; FIXME
+localparam MCU_SRAM_DATA_W = mci_mcu_sram_req_if.DATA_WIDTH;
 localparam MCU_SRAM_DATA_W_BYTES = MCU_SRAM_DATA_W / BITS_IN_BYTE;
-localparam MCU_SRAM_ECC_DATA_W = 7;//mci_mcu_sram_req_if.ECC_WIDTH; FIXME
+localparam MCU_SRAM_ECC_DATA_W = mci_mcu_sram_req_if.ECC_WIDTH;
 localparam MCU_SRAM_DATA_AND_ECC_W = MCU_SRAM_DATA_W + MCU_SRAM_ECC_DATA_W;
 localparam MCU_SRAM_DEPTH = MCU_SRAM_SIZE_BYTES / MCU_SRAM_DATA_W_BYTES;
 localparam MCU_SRAM_ADDR_W = $clog2(MCU_SRAM_DEPTH);

--- a/src/mci/rtl/mci_pkg.sv
+++ b/src/mci/rtl/mci_pkg.sv
@@ -28,6 +28,9 @@ package mci_pkg;
     parameter  MCI_WDT_TIMEOUT_PERIOD_NUM_DWORDS = 2;
     localparam MCI_WDT_TIMEOUT_PERIOD_W = MCI_WDT_TIMEOUT_PERIOD_NUM_DWORDS * 32;
 
+    parameter MCI_MBOX0_DMI_DLEN_ADDR = 0; //TODO define
+    parameter MCI_MBOX1_DMI_DLEN_ADDR = 0; //TODO define
+
     //Mailbox size configuration
     parameter MCI_MBOX0_SIZE_KB = 4;
     parameter MCI_MBOX0_DATA_W = 32;

--- a/src/mci/rtl/mci_pkg.sv
+++ b/src/mci/rtl/mci_pkg.sv
@@ -56,8 +56,8 @@ package mci_pkg;
         BOOT_LCC           = 4'b0011,
         BOOT_MCU           = 4'b0100,
         BOOT_PLL           = 4'b0101,
-        BOOT_WAIT_MCI    = 4'b0110,
-        BOOT_MCI         = 4'b0111,
+        BOOT_WAIT_CPTRA    = 4'b0110,
+        BOOT_CPTRA         = 4'b0111,
         BOOT_WAIT_UPDATE   = 4'b1000,
         BOOT_RST_MCU       = 4'b1001
     } mci_boot_fsm_state_e;

--- a/src/mci/rtl/mci_pkg.sv
+++ b/src/mci/rtl/mci_pkg.sv
@@ -28,6 +28,27 @@ package mci_pkg;
     parameter  MCI_WDT_TIMEOUT_PERIOD_NUM_DWORDS = 2;
     localparam MCI_WDT_TIMEOUT_PERIOD_W = MCI_WDT_TIMEOUT_PERIOD_NUM_DWORDS * 32;
 
+    //Mailbox size configuration
+    parameter MCI_MBOX0_SIZE_KB = 4;
+    parameter MCI_MBOX0_DATA_W = 32;
+    parameter MCI_MBOX0_ECC_DATA_W = 7;
+    parameter MCI_MBOX0_SIZE_BYTES = MCI_MBOX0_SIZE_KB * 1024;
+    parameter MCI_MBOX0_SIZE_DWORDS = MCI_MBOX0_SIZE_BYTES/4;
+    parameter MCI_MBOX0_DATA_AND_ECC_W = MCI_MBOX0_DATA_W + MCI_MBOX0_ECC_DATA_W;
+    parameter MCI_MBOX0_DEPTH = (MCI_MBOX0_SIZE_KB * 1024 * 8) / MCI_MBOX0_DATA_W;
+    parameter MCI_MBOX0_ADDR_W = $clog2(MCI_MBOX0_DEPTH);
+    parameter MCI_MBOX0_DEPTH_LOG2 = $clog2(MCI_MBOX0_DEPTH);
+
+    parameter MCI_MBOX1_SIZE_KB = 4;
+    parameter MCI_MBOX1_DATA_W = 32;
+    parameter MCI_MBOX1_ECC_DATA_W = 7;
+    parameter MCI_MBOX1_SIZE_BYTES = MCI_MBOX1_SIZE_KB * 1024;
+    parameter MCI_MBOX1_SIZE_DWORDS = MCI_MBOX1_SIZE_BYTES/4;
+    parameter MCI_MBOX1_DATA_AND_ECC_W = MCI_MBOX1_DATA_W + MCI_MBOX1_ECC_DATA_W;
+    parameter MCI_MBOX1_DEPTH = (MCI_MBOX1_SIZE_KB * 1024 * 8) / MCI_MBOX1_DATA_W;
+    parameter MCI_MBOX1_ADDR_W = $clog2(MCI_MBOX1_DEPTH);
+    parameter MCI_MBOX1_DEPTH_LOG2 = $clog2(MCI_MBOX1_DEPTH);
+
     typedef enum logic [3:0] {
         BOOT_IDLE          = 4'b0000,
         BOOT_FABRIC        = 4'b0001,
@@ -35,8 +56,8 @@ package mci_pkg;
         BOOT_LCC           = 4'b0011,
         BOOT_MCU           = 4'b0100,
         BOOT_PLL           = 4'b0101,
-        BOOT_WAIT_CPTRA    = 4'b0110,
-        BOOT_CPTRA         = 4'b0111,
+        BOOT_WAIT_MCI    = 4'b0110,
+        BOOT_MCI         = 4'b0111,
         BOOT_WAIT_UPDATE   = 4'b1000,
         BOOT_RST_MCU       = 4'b1001
     } mci_boot_fsm_state_e;

--- a/src/mci/rtl/mci_pkg.sv
+++ b/src/mci/rtl/mci_pkg.sv
@@ -21,36 +21,15 @@ package mci_pkg;
     localparam MB = KB * 1024;
     localparam MB_BASE0 = MB - 1;
 
+    localparam MCI_MBOX_DATA_W = 32; //not configurable
+    localparam MCI_MBOX_ECC_DATA_W = 7; //not configurable
+
     // Assert reset for 10 cycles then deassert
     // to facilitate the hitless update
     parameter MCI_MCU_UPDATE_RESET_CYLES = 10;
 
     parameter  MCI_WDT_TIMEOUT_PERIOD_NUM_DWORDS = 2;
     localparam MCI_WDT_TIMEOUT_PERIOD_W = MCI_WDT_TIMEOUT_PERIOD_NUM_DWORDS * 32;
-
-    parameter MCI_MBOX0_DMI_DLEN_ADDR = 0; //TODO define
-    parameter MCI_MBOX1_DMI_DLEN_ADDR = 0; //TODO define
-
-    //Mailbox size configuration
-    parameter MCI_MBOX0_SIZE_KB = 4;
-    parameter MCI_MBOX0_DATA_W = 32;
-    parameter MCI_MBOX0_ECC_DATA_W = 7;
-    parameter MCI_MBOX0_SIZE_BYTES = MCI_MBOX0_SIZE_KB * 1024;
-    parameter MCI_MBOX0_SIZE_DWORDS = MCI_MBOX0_SIZE_BYTES/4;
-    parameter MCI_MBOX0_DATA_AND_ECC_W = MCI_MBOX0_DATA_W + MCI_MBOX0_ECC_DATA_W;
-    parameter MCI_MBOX0_DEPTH = (MCI_MBOX0_SIZE_KB * 1024 * 8) / MCI_MBOX0_DATA_W;
-    parameter MCI_MBOX0_ADDR_W = $clog2(MCI_MBOX0_DEPTH);
-    parameter MCI_MBOX0_DEPTH_LOG2 = $clog2(MCI_MBOX0_DEPTH);
-
-    parameter MCI_MBOX1_SIZE_KB = 4;
-    parameter MCI_MBOX1_DATA_W = 32;
-    parameter MCI_MBOX1_ECC_DATA_W = 7;
-    parameter MCI_MBOX1_SIZE_BYTES = MCI_MBOX1_SIZE_KB * 1024;
-    parameter MCI_MBOX1_SIZE_DWORDS = MCI_MBOX1_SIZE_BYTES/4;
-    parameter MCI_MBOX1_DATA_AND_ECC_W = MCI_MBOX1_DATA_W + MCI_MBOX1_ECC_DATA_W;
-    parameter MCI_MBOX1_DEPTH = (MCI_MBOX1_SIZE_KB * 1024 * 8) / MCI_MBOX1_DATA_W;
-    parameter MCI_MBOX1_ADDR_W = $clog2(MCI_MBOX1_DEPTH);
-    parameter MCI_MBOX1_DEPTH_LOG2 = $clog2(MCI_MBOX1_DEPTH);
 
     typedef enum logic [3:0] {
         BOOT_IDLE          = 4'b0000,

--- a/src/mci/rtl/mci_top.sv
+++ b/src/mci/rtl/mci_top.sv
@@ -18,8 +18,13 @@ module mci_top
     import mci_pkg::*;
     import mbox_pkg::*;
     #(
-    parameter MCU_SRAM_SIZE_KB = 1024 // FIXME - write assertion ensuring this size 
-                                      // is compatible with the MCU SRAM IF parameters
+     parameter MCU_SRAM_SIZE_KB = 1024 // FIXME - write assertion ensuring this size 
+                                       // is compatible with the MCU SRAM IF parameters
+    //Mailbox configuration
+    ,parameter MCI_MBOX0_DMI_DLEN_ADDR = 0 //TODO define
+    ,parameter MCI_MBOX0_SIZE_KB = 4
+    ,parameter MCI_MBOX1_DMI_DLEN_ADDR = 0 //TODO define
+    ,parameter MCI_MBOX1_SIZE_KB = 4
     )
     (
     input logic clk,
@@ -151,9 +156,7 @@ cif_if #(
 //This wrapper decodes that protocol, collapses the full-duplex protocol to
 // simplex, and issues requests to the MIC decode block
 mci_axi_sub_top #( // FIXME: Should SUB and MAIN be under same AXI_TOP module?
-    .MCU_SRAM_SIZE_KB(MCU_SRAM_SIZE_KB),
-    .MBOX0_SIZE_KB (MCI_MBOX0_SIZE_KB),
-    .MBOX1_SIZE_KB  (MCI_MBOX1_SIZE_KB)
+    .MCU_SRAM_SIZE_KB(MCU_SRAM_SIZE_KB)
 ) i_mci_axi_sub_top (
     // MCI clk
     .clk  (clk     ),
@@ -308,7 +311,7 @@ if (MCI_MBOX0_SIZE_KB == 0) begin
         //TIE-OFF zero sized mailbox
         mci_mbox0_req_if.hold = 0;
         mci_mbox0_req_if.rdata = 0;
-        mci_mbox0_req_if.error = 0;
+        mci_mbox0_req_if.error = 1;
         mci_mbox0_sram_req_if.req.cs = 0;
         mci_mbox0_sram_req_if.req.we = 0;
         mci_mbox0_sram_req_if.req.addr = 0;
@@ -321,8 +324,8 @@ mbox
 #(
     .DMI_REG_MBOX_DLEN_ADDR(MCI_MBOX0_DMI_DLEN_ADDR),
     .MBOX_SIZE_KB(MCI_MBOX0_SIZE_KB),
-    .MBOX_DATA_W(MCI_MBOX0_DATA_W),
-    .MBOX_ECC_DATA_W(MCI_MBOX0_ECC_DATA_W),
+    .MBOX_DATA_W(MCI_MBOX_DATA_W),
+    .MBOX_ECC_DATA_W(MCI_MBOX_ECC_DATA_W),
     .MBOX_IFC_DATA_W(AXI_DATA_WIDTH),
     .MBOX_IFC_USER_W(AXI_USER_WIDTH),
     .MBOX_IFC_ADDR_W(AXI_ADDR_WIDTH)
@@ -337,7 +340,7 @@ mci_mbox0_i (
     .req_data_wdata(mci_mbox0_req_if.req_data.wdata),
     .req_data_user(mci_mbox0_req_if.req_data.user),
     .req_data_write(mci_mbox0_req_if.req_data.write),
-    .req_data_soc_req(clp_req), //FIXME is this right? Should it be ~mcu_req?
+    .req_data_soc_req(~mcu_req),
     .rdata(mci_mbox0_req_if.rdata),
     .mbox_error(mci_mbox0_req_if.error),
     .mbox_sram_req_cs(mci_mbox0_sram_req_if.req.cs),
@@ -391,7 +394,7 @@ if (MCI_MBOX1_SIZE_KB == 0) begin
         //TIE-OFF zero sized mailbox
         mci_mbox1_req_if.hold = 0;
         mci_mbox1_req_if.rdata = 0;
-        mci_mbox1_req_if.error = 0;
+        mci_mbox1_req_if.error = 1;
         mci_mbox1_sram_req_if.req.cs = 0;
         mci_mbox1_sram_req_if.req.we = 0;
         mci_mbox1_sram_req_if.req.addr = 0;
@@ -404,8 +407,8 @@ mbox
 #(
     .DMI_REG_MBOX_DLEN_ADDR(MCI_MBOX1_DMI_DLEN_ADDR),
     .MBOX_SIZE_KB(MCI_MBOX1_SIZE_KB),
-    .MBOX_DATA_W(MCI_MBOX1_DATA_W),
-    .MBOX_ECC_DATA_W(MCI_MBOX1_ECC_DATA_W),
+    .MBOX_DATA_W(MCI_MBOX_DATA_W),
+    .MBOX_ECC_DATA_W(MCI_MBOX_ECC_DATA_W),
     .MBOX_IFC_DATA_W(AXI_DATA_WIDTH),
     .MBOX_IFC_USER_W(AXI_USER_WIDTH),
     .MBOX_IFC_ADDR_W(AXI_ADDR_WIDTH)
@@ -420,7 +423,7 @@ mci_mbox1_i (
     .req_data_wdata(mci_mbox1_req_if.req_data.wdata),
     .req_data_user(mci_mbox1_req_if.req_data.user),
     .req_data_write(mci_mbox1_req_if.req_data.write),
-    .req_data_soc_req(clp_req), //FIXME is this right? Should it be ~mcu_req?
+    .req_data_soc_req(~mcu_req),
     .rdata(mci_mbox1_req_if.rdata),
     .mbox_error(mci_mbox1_req_if.error),
     .mbox_sram_req_cs(mci_mbox1_sram_req_if.req.cs),

--- a/src/mci/rtl/mci_top.sv
+++ b/src/mci/rtl/mci_top.sv
@@ -302,10 +302,24 @@ mci_reg_top i_mci_reg_top (
     .cif_resp_if (mci_reg_req_if.response)
 
 );
-
+generate
+if (MCI_MBOX0_SIZE_KB == 0) begin
+    always_comb begin
+        //TIE-OFF zero sized mailbox
+        mci_mbox0_req_if.hold = 0;
+        mci_mbox0_req_if.rdata = 0;
+        mci_mbox0_req_if.error = 0;
+        mci_mbox0_sram_req_if.req.cs = 0;
+        mci_mbox0_sram_req_if.req.we = 0;
+        mci_mbox0_sram_req_if.req.addr = 0;
+        mci_mbox0_sram_req_if.req.wdata = 0;
+        mbox0_sram_single_ecc_error = 0;
+        mbox0_sram_double_ecc_error = 0;
+    end
+end else begin
 mbox
 #(
-    .DMI_REG_MBOX_DLEN_ADDR(0),
+    .DMI_REG_MBOX_DLEN_ADDR(MCI_MBOX0_DMI_DLEN_ADDR),
     .MBOX_SIZE_KB(MCI_MBOX0_SIZE_KB),
     .MBOX_DATA_W(MCI_MBOX0_DATA_W),
     .MBOX_ECC_DATA_W(MCI_MBOX0_ECC_DATA_W),
@@ -368,11 +382,27 @@ mci_mbox0_i (
     .dmi_reg_wdata('0),
     .dmi_reg()
 );
+end
+endgenerate
 
-
+generate
+if (MCI_MBOX1_SIZE_KB == 0) begin
+    always_comb begin
+        //TIE-OFF zero sized mailbox
+        mci_mbox1_req_if.hold = 0;
+        mci_mbox1_req_if.rdata = 0;
+        mci_mbox1_req_if.error = 0;
+        mci_mbox1_sram_req_if.req.cs = 0;
+        mci_mbox1_sram_req_if.req.we = 0;
+        mci_mbox1_sram_req_if.req.addr = 0;
+        mci_mbox1_sram_req_if.req.wdata = 0;
+        mbox1_sram_single_ecc_error = 0;
+        mbox1_sram_double_ecc_error = 0;
+    end
+end else begin
 mbox
 #(
-    .DMI_REG_MBOX_DLEN_ADDR(0),
+    .DMI_REG_MBOX_DLEN_ADDR(MCI_MBOX1_DMI_DLEN_ADDR),
     .MBOX_SIZE_KB(MCI_MBOX1_SIZE_KB),
     .MBOX_DATA_W(MCI_MBOX1_DATA_W),
     .MBOX_ECC_DATA_W(MCI_MBOX1_ECC_DATA_W),
@@ -410,6 +440,21 @@ mci_mbox1_i (
     .soc_req_mbox_lock(), //FIXME
     .mbox_protocol_error(), //FIXME
     .mbox_inv_axi_user_axs(), //FIXME
+    //dma FIXME
+    .dma_sram_req_dv  ('0),
+    .dma_sram_req_write('0),
+    .dma_sram_req_addr('0),
+    .dma_sram_req_wdata('0),
+    .dma_sram_rdata   (),
+    .dma_sram_hold    (),
+    .dma_sram_error   (),
+    //dmi FIXME
+    .dmi_inc_rdptr('0),
+    .dmi_inc_wrptr('0),
+    .dmi_reg_wen('0),
+    .dmi_reg_addr('0),
+    .dmi_reg_wdata('0),
+    .dmi_reg(),
     //direct request unsupported
     .dir_req_dv(1'b0),
     .dir_rdata(),
@@ -418,22 +463,9 @@ mci_mbox1_i (
     .sha_sram_req_addr('0),
     .sha_sram_resp_ecc(),
     .sha_sram_resp_data(),
-    .sha_sram_hold(),
-    //dma unsupported
-    .dma_sram_req_dv  ('0),
-    .dma_sram_req_write('0),
-    .dma_sram_req_addr('0),
-    .dma_sram_req_wdata('0),
-    .dma_sram_rdata   (),
-    .dma_sram_hold    (),
-    .dma_sram_error   (),
-    //dmi port
-    .dmi_inc_rdptr('0),
-    .dmi_inc_wrptr('0),
-    .dmi_reg_wen('0),
-    .dmi_reg_addr('0),
-    .dmi_reg_wdata('0),
-    .dmi_reg()
+    .sha_sram_hold()
 );
+end
+endgenerate
 
 endmodule

--- a/src/mci/rtl/mci_top.sv
+++ b/src/mci/rtl/mci_top.sv
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+
 module mci_top 
     import mci_reg_pkg::*;
     import mci_pkg::*;
+    import mbox_pkg::*;
     #(
     parameter MCU_SRAM_SIZE_KB = 1024 // FIXME - write assertion ensuring this size 
                                       // is compatible with the MCU SRAM IF parameters
@@ -45,7 +47,13 @@ module mci_top
     output logic nmi_intr,
 
     // MCU SRAM Interface
-    mci_mcu_sram_if.request mci_mcu_sram_req_if 
+    mci_mcu_sram_if.request mci_mcu_sram_req_if,
+
+    // Mbox0 SRAM Interface
+    mci_mcu_sram_if.request mci_mbox0_sram_req_if,
+
+    // Mbox0 SRAM Interface
+    mci_mcu_sram_if.request mci_mbox1_sram_req_if 
 
     );
 
@@ -59,6 +67,12 @@ module mci_top
     // MCU SRAM signals
     logic mcu_sram_single_ecc_error;
     logic mcu_sram_double_ecc_error;
+
+    // Mbox0 SRAM signals
+    logic mbox0_sram_single_ecc_error;
+    logic mbox0_sram_double_ecc_error;
+    logic mbox1_sram_single_ecc_error;
+    logic mbox1_sram_double_ecc_error;
 
     // WDT signals
     logic timer1_en;
@@ -106,6 +120,30 @@ cif_if #(
     .clk, 
     .rst_b(mci_rst_b));
 
+// Caliptra internal fabric interface for MCI Mbox0
+// Address width is set to AXI_ADDR_WIDTH and Mbox0
+// will mask out upper bits that are "don't care"
+cif_if #(
+    .ADDR_WIDTH(AXI_ADDR_WIDTH)
+    ,.DATA_WIDTH(AXI_DATA_WIDTH)
+    ,.ID_WIDTH(AXI_ID_WIDTH)
+    ,.USER_WIDTH(AXI_USER_WIDTH)
+) mci_mbox0_req_if(
+    .clk, 
+    .rst_b(mci_rst_b));
+
+// Caliptra internal fabric interface for MCI Mbox0
+// Address width is set to AXI_ADDR_WIDTH and Mbox0
+// will mask out upper bits that are "don't care"
+cif_if #(
+    .ADDR_WIDTH(AXI_ADDR_WIDTH)
+    ,.DATA_WIDTH(AXI_DATA_WIDTH)
+    ,.ID_WIDTH(AXI_ID_WIDTH)
+    ,.USER_WIDTH(AXI_USER_WIDTH)
+) mci_mbox1_req_if(
+    .clk, 
+    .rst_b(mci_rst_b));
+
 
 //AXI Interface
 //This module contains the logic for interfacing with the SoC over the AXI Interface
@@ -114,8 +152,8 @@ cif_if #(
 // simplex, and issues requests to the MIC decode block
 mci_axi_sub_top #( // FIXME: Should SUB and MAIN be under same AXI_TOP module?
     .MCU_SRAM_SIZE_KB(MCU_SRAM_SIZE_KB),
-    .MBOX0_SIZE_KB (4),     // FIXME
-    .MBOX1_SIZE_KB  (4)     // FIXME
+    .MBOX0_SIZE_KB (MCI_MBOX0_SIZE_KB),
+    .MBOX1_SIZE_KB  (MCI_MBOX1_SIZE_KB)
 ) i_mci_axi_sub_top (
     // MCI clk
     .clk  (clk     ),
@@ -133,6 +171,11 @@ mci_axi_sub_top #( // FIXME: Should SUB and MAIN be under same AXI_TOP module?
     // MCU SRAM Interface
     .mcu_sram_req_if( mcu_sram_req_if.request ),
 
+    // MCI Mbox0 Interface
+    .mci_mbox0_req_if ( mci_mbox0_req_if.request ),
+
+    // MCI Mbox1 Interface
+    .mci_mbox1_req_if ( mci_mbox1_req_if.request ),
 
     // Privileged requests 
     .mcu_lsu_req,
@@ -260,6 +303,137 @@ mci_reg_top i_mci_reg_top (
 
 );
 
+mbox
+#(
+    .DMI_REG_MBOX_DLEN_ADDR(0),
+    .MBOX_SIZE_KB(MCI_MBOX0_SIZE_KB),
+    .MBOX_DATA_W(MCI_MBOX0_DATA_W),
+    .MBOX_ECC_DATA_W(MCI_MBOX0_ECC_DATA_W),
+    .MBOX_IFC_DATA_W(AXI_DATA_WIDTH),
+    .MBOX_IFC_USER_W(AXI_USER_WIDTH),
+    .MBOX_IFC_ADDR_W(AXI_ADDR_WIDTH)
+)
+mci_mbox0_i (
+    .clk(clk),
+    .rst_b(mci_rst_b),
+    //mailbox request interface
+    .req_dv(mci_mbox0_req_if.dv), 
+    .req_hold(mci_mbox0_req_if.hold),
+    .req_data_addr(mci_mbox0_req_if.req_data.addr),
+    .req_data_wdata(mci_mbox0_req_if.req_data.wdata),
+    .req_data_user(mci_mbox0_req_if.req_data.user),
+    .req_data_write(mci_mbox0_req_if.req_data.write),
+    .req_data_soc_req(clp_req), //FIXME is this right? Should it be ~mcu_req?
+    .rdata(mci_mbox0_req_if.rdata),
+    .mbox_error(mci_mbox0_req_if.error),
+    .mbox_sram_req_cs(mci_mbox0_sram_req_if.req.cs),
+    .mbox_sram_req_we(mci_mbox0_sram_req_if.req.we), 
+    .mbox_sram_req_addr(mci_mbox0_sram_req_if.req.addr),
+    .mbox_sram_req_ecc(mci_mbox0_sram_req_if.req.wdata.ecc),
+    .mbox_sram_req_wdata(mci_mbox0_sram_req_if.req.wdata.data),
+    .mbox_sram_resp_ecc(mci_mbox0_sram_req_if.resp.rdata.ecc),
+    .mbox_sram_resp_data(mci_mbox0_sram_req_if.resp.rdata.data),
+    .sram_single_ecc_error(mbox0_sram_single_ecc_error),
+    .sram_double_ecc_error(mbox0_sram_double_ecc_error),
+    //status
+    .uc_mbox_lock(), //FIXME
+    //interrupts
+    .soc_mbox_data_avail(), //FIXME
+    .uc_mbox_data_avail(), //FIXME
+    .soc_req_mbox_lock(), //FIXME
+    .mbox_protocol_error(), //FIXME
+    .mbox_inv_axi_user_axs(), //FIXME
+    //direct request unsupported
+    .dir_req_dv(1'b0),
+    .dir_rdata(),
+    //sha accelerator unsupported
+    .sha_sram_req_dv('0),
+    .sha_sram_req_addr('0),
+    .sha_sram_resp_ecc(),
+    .sha_sram_resp_data(),
+    .sha_sram_hold(),
+    //dma unsupported
+    .dma_sram_req_dv  ('0),
+    .dma_sram_req_write('0),
+    .dma_sram_req_addr('0),
+    .dma_sram_req_wdata('0),
+    .dma_sram_rdata   (),
+    .dma_sram_hold    (),
+    .dma_sram_error   (),
+    //dmi port
+    .dmi_inc_rdptr('0),
+    .dmi_inc_wrptr('0),
+    .dmi_reg_wen('0),
+    .dmi_reg_addr('0),
+    .dmi_reg_wdata('0),
+    .dmi_reg()
+);
 
+
+mbox
+#(
+    .DMI_REG_MBOX_DLEN_ADDR(0),
+    .MBOX_SIZE_KB(MCI_MBOX1_SIZE_KB),
+    .MBOX_DATA_W(MCI_MBOX1_DATA_W),
+    .MBOX_ECC_DATA_W(MCI_MBOX1_ECC_DATA_W),
+    .MBOX_IFC_DATA_W(AXI_DATA_WIDTH),
+    .MBOX_IFC_USER_W(AXI_USER_WIDTH),
+    .MBOX_IFC_ADDR_W(AXI_ADDR_WIDTH)
+)
+mci_mbox1_i (
+    .clk(clk),
+    .rst_b(mci_rst_b),
+    //mailbox request interface
+    .req_dv(mci_mbox1_req_if.dv), 
+    .req_hold(mci_mbox1_req_if.hold),
+    .req_data_addr(mci_mbox1_req_if.req_data.addr),
+    .req_data_wdata(mci_mbox1_req_if.req_data.wdata),
+    .req_data_user(mci_mbox1_req_if.req_data.user),
+    .req_data_write(mci_mbox1_req_if.req_data.write),
+    .req_data_soc_req(clp_req), //FIXME is this right? Should it be ~mcu_req?
+    .rdata(mci_mbox1_req_if.rdata),
+    .mbox_error(mci_mbox1_req_if.error),
+    .mbox_sram_req_cs(mci_mbox1_sram_req_if.req.cs),
+    .mbox_sram_req_we(mci_mbox1_sram_req_if.req.we), 
+    .mbox_sram_req_addr(mci_mbox1_sram_req_if.req.addr),
+    .mbox_sram_req_ecc(mci_mbox1_sram_req_if.req.wdata.ecc),
+    .mbox_sram_req_wdata(mci_mbox1_sram_req_if.req.wdata.data),
+    .mbox_sram_resp_ecc(mci_mbox1_sram_req_if.resp.rdata.ecc),
+    .mbox_sram_resp_data(mci_mbox1_sram_req_if.resp.rdata.data),
+    .sram_single_ecc_error(mbox1_sram_single_ecc_error),
+    .sram_double_ecc_error(mbox1_sram_double_ecc_error),
+    //status
+    .uc_mbox_lock(), //FIXME
+    //interrupts
+    .soc_mbox_data_avail(), //FIXME
+    .uc_mbox_data_avail(), //FIXME
+    .soc_req_mbox_lock(), //FIXME
+    .mbox_protocol_error(), //FIXME
+    .mbox_inv_axi_user_axs(), //FIXME
+    //direct request unsupported
+    .dir_req_dv(1'b0),
+    .dir_rdata(),
+    //sha accelerator unsupported
+    .sha_sram_req_dv('0),
+    .sha_sram_req_addr('0),
+    .sha_sram_resp_ecc(),
+    .sha_sram_resp_data(),
+    .sha_sram_hold(),
+    //dma unsupported
+    .dma_sram_req_dv  ('0),
+    .dma_sram_req_write('0),
+    .dma_sram_req_addr('0),
+    .dma_sram_req_wdata('0),
+    .dma_sram_rdata   (),
+    .dma_sram_hold    (),
+    .dma_sram_error   (),
+    //dmi port
+    .dmi_inc_rdptr('0),
+    .dmi_inc_wrptr('0),
+    .dmi_reg_wen('0),
+    .dmi_reg_addr('0),
+    .dmi_reg_wdata('0),
+    .dmi_reg()
+);
 
 endmodule

--- a/src/mci/rtl/mci_top.sv
+++ b/src/mci/rtl/mci_top.sv
@@ -52,7 +52,7 @@ module mci_top
     // Mbox0 SRAM Interface
     mci_mcu_sram_if.request mci_mbox0_sram_req_if,
 
-    // Mbox0 SRAM Interface
+    // Mbox1 SRAM Interface
     mci_mcu_sram_if.request mci_mbox1_sram_req_if 
 
     );

--- a/src/mci/tb/mci_top_tb.sv
+++ b/src/mci/tb/mci_top_tb.sv
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//======================================================================
+//======================================================================
+
+module mci_top_tb
+  import mci_pkg::*;
+  import axi_pkg::*;
+  ();
+
+  // MCI AXI Interface
+  axi_if s_axi_w_if();
+  axi_if s_axi_r_if();
+
+  // MCU SRAM Interface
+  mci_mcu_sram_if mci_mcu_sram_req_if();
+
+  // Mbox0 SRAM Interface
+  mci_mcu_sram_if#(.ADDR_WIDTH(MCI_MBOX0_ADDR_W)) mci_mbox0_sram_req_if();
+
+  // Mbox0 SRAM Interface
+  mci_mcu_sram_if#(.ADDR_WIDTH(MCI_MBOX1_ADDR_W)) mci_mbox1_sram_req_if(); 
+
+  logic clk;
+
+  // MCI Resets
+  logic mci_rst_b;
+  logic mci_pwrgood;
+  
+  // Straps
+  logic [s_axi_r_if.UW-1:0] strap_mcu_lsu_axi_user;
+  logic [s_axi_r_if.UW-1:0] strap_mcu_ifu_axi_user;
+  logic [s_axi_r_if.UW-1:0] strap_clp_axi_user;
+
+  // SRAM ADHOC connections
+  logic mcu_sram_fw_exec_region_lock;
+
+  // SOC Interrupts
+  logic error_fatal;
+
+  // NMI Vector 
+  logic nmi_intr;
+
+  mci_top
+  mci_top_inst
+  (
+  .clk,
+
+  // MCI Resets
+  .mci_rst_b,
+  .mci_pwrgood,
+
+  // MCI AXI Interface
+  .s_axi_w_if,
+  .s_axi_r_if,
+  
+  // Straps
+  .strap_mcu_lsu_axi_user,
+  .strap_mcu_ifu_axi_user,
+  .strap_clp_axi_user,
+
+  // SRAM ADHOC connections
+  .mcu_sram_fw_exec_region_lock,
+
+  // SOC Interrupts
+  .error_fatal,
+
+  // NMI Vector 
+  .nmi_intr,
+
+  // MCU SRAM Interface
+  .mci_mcu_sram_req_if,
+
+  // Mbox0 SRAM Interface
+  .mci_mbox0_sram_req_if,
+
+  // Mbox0 SRAM Interface
+  .mci_mbox1_sram_req_if 
+  );
+
+endmodule

--- a/src/mci/tb/mci_top_tb.sv
+++ b/src/mci/tb/mci_top_tb.sv
@@ -20,6 +20,21 @@ module mci_top_tb
   import axi_pkg::*;
   ();
 
+  parameter MCI_TB_MCU_SRAM_SIZE_KB = 1024;
+
+  //Mailbox configuration
+  parameter MCI_TB_MBOX0_DMI_DLEN_ADDR = 0; //TODO define
+  parameter MCI_TB_MBOX0_SIZE_KB = 4;
+  localparam MCI_TB_MBOX0_DEPTH = (MCI_TB_MBOX0_SIZE_KB * KB * 8) / MCI_MBOX_DATA_W;
+  localparam MCI_TB_MBOX0_ADDR_W = $clog2(MCI_TB_MBOX0_DEPTH);
+  localparam MCI_TB_MBOX0_DEPTH_LOG2 = $clog2(MCI_TB_MBOX0_DEPTH);
+
+  parameter MCI_TB_MBOX1_DMI_DLEN_ADDR = 0; //TODO define
+  parameter MCI_TB_MBOX1_SIZE_KB = 4;
+  localparam MCI_TB_MBOX1_DEPTH = (MCI_TB_MBOX1_SIZE_KB * KB * 8) / MCI_MBOX_DATA_W;
+  localparam MCI_TB_MBOX1_ADDR_W = $clog2(MCI_TB_MBOX1_DEPTH);
+  localparam MCI_TB_MBOX1_DEPTH_LOG2 = $clog2(MCI_TB_MBOX1_DEPTH);
+
   // MCI AXI Interface
   axi_if s_axi_w_if();
   axi_if s_axi_r_if();
@@ -28,10 +43,10 @@ module mci_top_tb
   mci_mcu_sram_if mci_mcu_sram_req_if();
 
   // Mbox0 SRAM Interface
-  mci_mcu_sram_if#(.ADDR_WIDTH(MCI_MBOX0_ADDR_W)) mci_mbox0_sram_req_if();
+  mci_mcu_sram_if#(.ADDR_WIDTH(MCI_TB_MBOX0_ADDR_W)) mci_mbox0_sram_req_if();
 
   // Mbox0 SRAM Interface
-  mci_mcu_sram_if#(.ADDR_WIDTH(MCI_MBOX1_ADDR_W)) mci_mbox1_sram_req_if(); 
+  mci_mcu_sram_if#(.ADDR_WIDTH(MCI_TB_MBOX1_ADDR_W)) mci_mbox1_sram_req_if(); 
 
   logic clk;
 
@@ -54,6 +69,15 @@ module mci_top_tb
   logic nmi_intr;
 
   mci_top
+  #(
+    .MCU_SRAM_SIZE_KB(MCI_TB_MCU_SRAM_SIZE_KB), 
+
+    //Mailbox configuration
+    .MCI_MBOX0_DMI_DLEN_ADDR(MCI_TB_MBOX0_DMI_DLEN_ADDR),
+    .MCI_MBOX0_SIZE_KB(MCI_TB_MBOX0_SIZE_KB),
+    .MCI_MBOX1_DMI_DLEN_ADDR(MCI_TB_MBOX1_DMI_DLEN_ADDR),
+    .MCI_MBOX1_SIZE_KB(MCI_TB_MBOX1_SIZE_KB)
+  )
   mci_top_inst
   (
   .clk,


### PR DESCRIPTION
updating caliptra-rtl to include parameterized mailbox
Updates to MCI block to instantiate two mbox instances and connect to axi interface