### PR TITLE
User/ekarabulut/lc fc test adjs

### DIFF
--- a/src/fuse_ctrl/rtl/otp_ctrl_reg_pkg.sv
+++ b/src/fuse_ctrl/rtl/otp_ctrl_reg_pkg.sv
@@ -8,7 +8,7 @@ package otp_ctrl_reg_pkg;
 
   // Param list
   parameter int NumSramKeyReqSlots = 4;
-  parameter int OtpByteAddrWidth = 13;
+  parameter int OtpByteAddrWidth = 12;
   parameter int NumErrorEntries = 16;
   parameter int NumDaiWords = 2;
   parameter int NumDigestWords = 2;

--- a/src/integration/test_suites/caliptra_ss_lc_ctrl_st_trans/caliptra_ss_lc_ctrl_st_trans.c
+++ b/src/integration/test_suites/caliptra_ss_lc_ctrl_st_trans/caliptra_ss_lc_ctrl_st_trans.c
@@ -10,7 +10,7 @@
 #include <time.h>
 #include <stdlib.h>
 
-volatile char* stdout = (char *)0xd0580000;
+volatile char* stdout = (char *)0x21000410;
 #ifdef CPT_VERBOSITY
     enum printf_verbosity verbosity_g = CPT_VERBOSITY;
 #else
@@ -380,6 +380,18 @@ void main (void) {
                              0xffffffff };
     uint32_t mbox_resp_dlen;
     uint32_t mbox_resp_data;
+    uint32_t cptra_boot_go;
+    VPRINTF(LOW, "=================\nMCU Caliptra Boot Go\n=================\n\n")
+    
+    // Writing to Caliptra Boot GO register of MCI for CSS BootFSM to bring Caliptra out of reset 
+    // This is just to see CSSBootFSM running correctly
+    lsu_write_32(SOC_MCI_REG_CALIPTRA_BOOT_GO, 1);
+    VPRINTF(LOW, "MCU: Writing MCI SOC_MCI_REG_CALIPTRA_BOOT_GO\n");
+
+    cptra_boot_go = lsu_read_32(SOC_MCI_REG_CALIPTRA_BOOT_GO);
+    VPRINTF(LOW, "MCU: Reading SOC_MCI_REG_CALIPTRA_BOOT_GO %x\n", cptra_boot_go);
+
+
     
     VPRINTF(LOW, "=================\n LCC State Transitions \n=================\n\n");
 

--- a/src/integration/test_suites/fuse_prov_with_lc_ctrl/fuse_prov_with_lc_ctrl.c
+++ b/src/integration/test_suites/fuse_prov_with_lc_ctrl/fuse_prov_with_lc_ctrl.c
@@ -10,7 +10,7 @@
 #include <time.h>
 #include <stdlib.h>
 
-volatile char* stdout = (char *)0xd0580000;
+volatile char* stdout = (char *)0x21000410;
 #ifdef CPT_VERBOSITY
     enum printf_verbosity verbosity_g = CPT_VERBOSITY;
 #else
@@ -667,8 +667,20 @@ void main (void) {
                              0xffffffff };
     uint32_t mbox_resp_dlen;
     uint32_t mbox_resp_data;
+    uint32_t cptra_boot_go;
+    VPRINTF(LOW, "=================\nMCU Caliptra Boot Go\n=================\n\n")
     
-    VPRINTF(LOW, "=================\n LCC State Transitions \n=================\n\n");
+    // Writing to Caliptra Boot GO register of MCI for CSS BootFSM to bring Caliptra out of reset 
+    // This is just to see CSSBootFSM running correctly
+    lsu_write_32(SOC_MCI_REG_CALIPTRA_BOOT_GO, 1);
+    VPRINTF(LOW, "MCU: Writing MCI SOC_MCI_REG_CALIPTRA_BOOT_GO\n");
+
+    cptra_boot_go = lsu_read_32(SOC_MCI_REG_CALIPTRA_BOOT_GO);
+    VPRINTF(LOW, "MCU: Reading SOC_MCI_REG_CALIPTRA_BOOT_GO %x\n", cptra_boot_go);
+
+
+    
+    VPRINTF(LOW, "=================\n Fuse Prov TEST \n=================\n\n");
 
 
     lcc_initilization();    


### PR DESCRIPTION
1. Updated FC and LCC smoke test by updating mem pointer address
2. Added caliptra go steps in FC and LCC tests
3. Changed OTP mem address width since reads sending 0s.
4. Tested LCC and OTP. LCC can perform state transitions.
5. OTP controller can provision uds, which was tested.