### PR TITLE
[fuse_ctrl, integration] Fix fuse_ctrl background checks init error

### DIFF
--- a/docs/CaliptraSSHardwareSpecification.md
+++ b/docs/CaliptraSSHardwareSpecification.md
@@ -320,10 +320,10 @@ The OTP controller initializes automatically upon power-up and is fully operatio
 The only initialization steps that SW should perform are:
 
 1. Check that the OTP controller has successfully initialized by reading [`STATUS`](../src/fuse_ctrl/doc/registers.md#status). I.e., make sure that none of the ERROR bits are set, and that the DAI is idle ([`STATUS.DAI_IDLE`](../src/fuse_ctrl/doc/registers.md#status)).
-2. Set up the periodic background checks:
-    - Choose whether to enable periodic background checks by programming nonzero mask values to [`INTEGRITY_CHECK_PERIOD`](../src/fuse_ctrl/doc/registers.md#integrity_check_period) and [`CONSISTENCY_CHECK_PERIOD`](../src/fuse_ctrl/doc/registers.md#consistency_check_period).
-    - Choose whether such checks shall be subject to a timeout by programming a nonzero timeout cycle count to [`CHECK_TIMEOUT`](../src/fuse_ctrl/doc/registers.md#check_timeout).
-    - It is recommended to lock down the background check registers via [`CHECK_REGWEN`](../src/fuse_ctrl/doc/registers.md#check_regwen), once the background checks have been set up.
+    - Choose whether the periodic [background checks](#partition-checks) shall be subject to a timeout by programming a nonzero timeout cycle count to [`CHECK_TIMEOUT`](registers.md#check_timeout).
+      In this case, the [`CHECK_TIMEOUT`](registers.md#check_timeout) register must be set before the [`INTEGRITY_CHECK_PERIOD`](registers.md#integrity_check_period) and [`CONSISTENCY_CHECK_PERIOD`](registers.md#consistency_check_period) registers (see next point).
+    - Enable periodic [background checks](#partition-checks) by programming nonzero mask values to [`INTEGRITY_CHECK_PERIOD`](registers.md#integrity_check_period) and [`CONSISTENCY_CHECK_PERIOD`](registers.md#consistency_check_period).
+    - It is recommended to lock down the background check registers via [`CHECK_REGWEN`](registers.md#check_regwen), once the background checks have been set up
 
 If needed, one-off integrity and consistency checks can be triggered via [`CHECK_TRIGGER`](../src/fuse_ctrl/doc/registers.md#check_trigger).
 If this functionality is not needed, it is recommended to lock down the trigger register via [`CHECK_TRIGGER_REGWEN`](../src/fuse_ctrl/doc/registers.md#check_trigger_regwen).

--- a/src/integration/test_suites/smoke_test_fuse_prov_with_lcc/smoke_test_fuse_prov_with_lcc.c
+++ b/src/integration/test_suites/smoke_test_fuse_prov_with_lcc/smoke_test_fuse_prov_with_lcc.c
@@ -414,25 +414,29 @@ void initialize_otp_controller() {
     // Step 2: Set up periodic background checks
     VPRINTF(LOW, "DEBUG: Configuring periodic background checks...\n");
 
+    // Configure CHECK_TIMEOUT
+    // Note that the CHECK_TIMEOUT register needs to be written before
+    // INTEGRITY_CHECK_PERIOD or CONSISTENCY_CHECK_PERIOD or a preemptive
+    // spurious timeout is triggered that that transfers the fuse_ctrl into
+    // an error state.
+    uint32_t check_timeout = 0x10000; // Example value, adjust as needed
+    lsu_write_32(FUSE_CTRL_CHECK_TIMEOUT, check_timeout);
+    VPRINTF(LOW, "INFO: CHECK_TIMEOUT set to 0x%08X\n", check_timeout);
+
     // Configure INTEGRITY_CHECK_PERIOD
-    // uint32_t integrity_check_period = 0x100; // Example value, adjust as needed
-    // lsu_write_32(FUSE_CTRL_INTEGRITY_CHECK_PERIOD, integrity_check_period);
-    // VPRINTF(LOW, "INFO: INTEGRITY_CHECK_PERIOD set to 0x%08X\n", integrity_check_period);
+    uint32_t integrity_check_period = 0x3FFFF; // Example value, adjust as needed
+    lsu_write_32(FUSE_CTRL_INTEGRITY_CHECK_PERIOD, integrity_check_period);
+    VPRINTF(LOW, "INFO: INTEGRITY_CHECK_PERIOD set to 0x%08X\n", integrity_check_period);
 
-    // // Configure CONSISTENCY_CHECK_PERIOD
-    // uint32_t consistency_check_period = 0x100; // Example value, adjust as needed
-    // lsu_write_32(FUSE_CTRL_CONSISTENCY_CHECK_PERIOD, consistency_check_period);
-    // VPRINTF(LOW, "INFO: CONSISTENCY_CHECK_PERIOD set to 0x%08X\n", consistency_check_period);
+    // Configure CONSISTENCY_CHECK_PERIOD
+    uint32_t consistency_check_period = 0x3FFFF; // Example value, adjust as needed
+    lsu_write_32(FUSE_CTRL_CONSISTENCY_CHECK_PERIOD, consistency_check_period);
+    VPRINTF(LOW, "INFO: CONSISTENCY_CHECK_PERIOD set to 0x%08X\n", consistency_check_period);
 
-    // // Configure CHECK_TIMEOUT
-    // uint32_t check_timeout = 0x1000; // Example value, adjust as needed
-    // lsu_write_32(FUSE_CTRL_CHECK_TIMEOUT, check_timeout);
-    // VPRINTF(LOW, "INFO: CHECK_TIMEOUT set to 0x%08X\n", check_timeout);
-
-    // // Step 3: Lock down background check registers
-    // VPRINTF(LOW, "DEBUG: Locking background check registers...\n");
-    // lsu_write_32(FUSE_CTRL_CHECK_REGWEN, 0x0);
-    // VPRINTF(LOW, "INFO: CHECK_REGWEN locked.\n");
+    // Step 3: Lock down background check registers
+    VPRINTF(LOW, "DEBUG: Locking background check registers...\n");
+    lsu_write_32(FUSE_CTRL_CHECK_REGWEN, 0x0);
+    VPRINTF(LOW, "INFO: CHECK_REGWEN locked.\n");
 
     
 }


### PR DESCRIPTION
This reinstates the background checks in the fuse_ctrl provisioning smoke tests by fixing the order of registers write to enable the periodic integrity and consistency checks.

The CHECK_TIMEOUT register needs to be written before INTEGRITY_CHECK_PERIOD and CONSISTENCY_CHECK_PERIOD or an unintended timeout error is triggered.

Related OpenTitan PR: https://github.com/lowRISC/opentitan/pull/26188