### PR TITLE
[fuse_ctrl, rtl] Use the latched AXI user id in the filter logic

### DIFF
--- a/src/fuse_ctrl/rtl/fuse_ctrl_filter.sv
+++ b/src/fuse_ctrl/rtl/fuse_ctrl_filter.sv
@@ -102,7 +102,7 @@ always_comb begin
     for (int i = 0; i < FC_TABLE_NUM_RANGES; i = i + 1) begin : gen_wr_allowed
         wr_allowed_vec[i] = ((latched_fuse_addr >= access_control_table[i].lower_addr) &&
                                     (latched_fuse_addr <= access_control_table[i].upper_addr) &&
-                                    (req_axi_user_id == access_control_table[i].axi_user_id));
+                                    (latched_data_id0 == access_control_table[i].axi_user_id));
     end
 end
 


### PR DESCRIPTION
The latched AXI user id signal needs to be used in the fuse_ctrl filter logic in order to correctly deduce whether a DAI write needs to be discarded. Otherwise, any write is discarded by default as the AXI user id port is not stable long enough for a successful address resolution.