### PR TITLE
fix: Use correct field property in wdata

### DIFF
--- a/src/fuse_ctrl/data/otp_ctrl.rdl
+++ b/src/fuse_ctrl/data/otp_ctrl.rdl
@@ -268,8 +268,8 @@ addrmap caliptra_otp_ctrl {
                     Hardware automatically determines the access granule (32bit or 64bit) based on which 
                     partition is being written to.";
 
-            default sw = r; // field prperty
-            default hw = w; // field prperty
+            default sw = w; // field prperty
+            default hw = r; // field prperty
 
             field { desc = "wdata.";} WDATA [31:0];
         };


### PR DESCRIPTION
This should be write only from the software perspective.