### PR TITLE
[fuse_ctrl, rtl] Lock partitions depending on LC state

### DIFF
--- a/src/fuse_ctrl/data/otp_ctrl.hjson
+++ b/src/fuse_ctrl/data/otp_ctrl.hjson
@@ -1,3 +1,4 @@
+// Copyright lowRISC contributors (OpenTitan project).
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/fuse_ctrl/data/otp_ctrl_mmap.hjson
+++ b/src/fuse_ctrl/data/otp_ctrl_mmap.hjson
@@ -68,16 +68,17 @@
     // Note that the digest items are added automatically to the address map.
     partitions: [
         {
-            name:       "SECRET_TEST_UNLOCK_PARTITION",
-            variant:    "Buffered",
-            secret:     true,
-            sw_digest:  false,
-            hw_digest:  true,
-            write_lock: "Digest",
-            read_lock:  "Digest",
-            key_sel:    "SecretTestUnlockKey",
-            integrity:  true,
-            bkout_type: true,
+            name:         "SECRET_TEST_UNLOCK_PARTITION",
+            variant:      "Buffered",
+            secret:       true,
+            sw_digest:    false,
+            hw_digest:    true,
+            write_lock:   "Digest",
+            read_lock:    "Digest",
+            key_sel:      "SecretTestUnlockKey",
+            integrity:    true,
+            bkout_type:   true,
+            lc_state_idx: 16,
             items: [
                 {
                     name: "CPTRA_CORE_MANUF_DEBUG_UNLOCK_TOKEN",
@@ -91,16 +92,17 @@
             '''
         },
         {
-            name:       "SECRET_MANUF_PARTITION",
-            variant:    "Buffered",
-            secret:     true,
-            sw_digest:  false,
-            hw_digest:  true,
-            write_lock: "Digest",
-            read_lock:  "Digest",
-            key_sel:    "SecretManufKey",
-            integrity:  true,
-            bkout_type: true,
+            name:         "SECRET_MANUF_PARTITION",
+            variant:      "Buffered",
+            secret:       true,
+            sw_digest:    false,
+            hw_digest:    true,
+            write_lock:   "Digest",
+            read_lock:    "Digest",
+            key_sel:      "SecretManufKey",
+            integrity:    true,
+            bkout_type:   true,
+            lc_state_idx: 16,
             items: [
                 {
                     name: "CPTRA_CORE_UDS_SEED",
@@ -116,16 +118,17 @@
             '''
         },
         {
-            name:       "SECRET_PROD_PARTITION_0",
-            variant:    "Buffered",
-            secret:     true,
-            sw_digest:  false,
-            hw_digest:  true,
-            write_lock: "Digest",
-            read_lock:  "Digest",
-            key_sel:    "SecretProdKey0",
-            integrity:  true,
-            bkout_type: true,
+            name:         "SECRET_PROD_PARTITION_0",
+            variant:      "Buffered",
+            secret:       true,
+            sw_digest:    false,
+            hw_digest:    true,
+            write_lock:   "Digest",
+            read_lock:    "Digest",
+            key_sel:      "SecretProdKey0",
+            integrity:    true,
+            bkout_type:   true,
+            lc_state_idx: 17,
             items: [
                 {
                     name: "CPTRA_CORE_FIELD_ENTROPY_0",
@@ -141,16 +144,17 @@
             '''
         },
         {
-            name:       "SECRET_PROD_PARTITION_1",
-            variant:    "Buffered",
-            secret:     true,
-            sw_digest:  false,
-            hw_digest:  true,
-            write_lock: "Digest",
-            read_lock:  "Digest",
-            key_sel:    "SecretProdKey1",
-            integrity:  true,
-            bkout_type: true,
+            name:         "SECRET_PROD_PARTITION_1",
+            variant:      "Buffered",
+            secret:       true,
+            sw_digest:    false,
+            hw_digest:    true,
+            write_lock:   "Digest",
+            read_lock:    "Digest",
+            key_sel:      "SecretProdKey1",
+            integrity:    true,
+            bkout_type:   true,
+            lc_state_idx: 17,
             items: [
                 {
                     name: "CPTRA_CORE_FIELD_ENTROPY_1",
@@ -166,16 +170,17 @@
             '''
         },
         {
-            name:       "SECRET_PROD_PARTITION_2",
-            variant:    "Buffered",
-            secret:     true,
-            sw_digest:  false,
-            hw_digest:  true,
-            write_lock: "Digest",
-            read_lock:  "Digest",
-            key_sel:    "SecretProdKey2",
-            integrity:  true,
-            bkout_type: true,
+            name:         "SECRET_PROD_PARTITION_2",
+            variant:      "Buffered",
+            secret:       true,
+            sw_digest:    false,
+            hw_digest:    true,
+            write_lock:   "Digest",
+            read_lock:    "Digest",
+            key_sel:      "SecretProdKey2",
+            integrity:    true,
+            bkout_type:   true,
+            lc_state_idx: 17,
             items: [
                 {
                     name: "CPTRA_CORE_FIELD_ENTROPY_2",
@@ -191,16 +196,17 @@
             '''
         },
         {
-            name:       "SECRET_PROD_PARTITION_3",
-            variant:    "Buffered",
-            secret:     true,
-            sw_digest:  false,
-            hw_digest:  true,
-            write_lock: "Digest",
-            read_lock:  "Digest",
-            key_sel:    "SecretProdKey3",
-            integrity:  true,
-            bkout_type: true,
+            name:         "SECRET_PROD_PARTITION_3",
+            variant:      "Buffered",
+            secret:       true,
+            sw_digest:    false,
+            hw_digest:    true,
+            write_lock:   "Digest",
+            read_lock:    "Digest",
+            key_sel:      "SecretProdKey3",
+            integrity:    true,
+            bkout_type:   true,
+            lc_state_idx: 17,
             items: [
                 {
                     name: "CPTRA_CORE_FIELD_ENTROPY_3",
@@ -216,17 +222,18 @@
             '''
         },
         {
-            name:       "SW_MANUF_PARTITION",
-            variant:    "Unbuffered",
-            absorb:     true,
-            secret:     false,
-            sw_digest:  true,
-            hw_digest:  false,
-            write_lock: "Digest",
-            read_lock:  "CSR",
-            key_sel:    "NoKey",
-            integrity:  true,
-            bkout_type: false,
+            name:         "SW_MANUF_PARTITION",
+            variant:      "Unbuffered",
+            absorb:       true,
+            secret:       false,
+            sw_digest:    true,
+            hw_digest:    false,
+            write_lock:   "Digest",
+            read_lock:    "CSR",
+            key_sel:      "NoKey",
+            integrity:    true,
+            bkout_type:   false,
+            lc_state_idx: 16,
             items: [
                 {
                     name: "CPTRA_CORE_ANTI_ROLLBACK_DISABLE",
@@ -273,16 +280,17 @@
             '''
         },
         {
-            name:       "SECRET_LC_TRANSITION_PARTITION",
-            variant:    "Buffered",
-            secret:     true,
-            sw_digest:  false,
-            hw_digest:  true,
-            write_lock: "Digest",
-            read_lock:  "Digest",
-            key_sel:    "SecretLifeCycleTransitionKey",
-            integrity:  true,
-            bkout_type: false,
+            name:         "SECRET_LC_TRANSITION_PARTITION",
+            variant:      "Buffered",
+            secret:       true,
+            sw_digest:    false,
+            hw_digest:    true,
+            write_lock:   "Digest",
+            read_lock:    "Digest",
+            key_sel:      "SecretLifeCycleTransitionKey",
+            integrity:    true,
+            bkout_type:   false,
+            lc_state_idx: 16,
             items: [
                 {
                     name: "CPTRA_SS_TEST_UNLOCK_TOKEN_0",
@@ -353,19 +361,20 @@
             '''
         },
         {
-            name:       "SVN_PARTITION",
-            variant:    "Unbuffered",
-            absorb:     false,
-            secret:     false,
-            sw_digest:  false,
-            hw_digest:  false,
-            write_lock: "None",
-            read_lock:  "CSR",
-            key_sel:    "NoKey",
+            name:         "SVN_PARTITION",
+            variant:      "Unbuffered",
+            absorb:       false,
+            secret:       false,
+            sw_digest:    false,
+            hw_digest:    false,
+            write_lock:   "None",
+            read_lock:    "CSR",
+            key_sel:      "NoKey",
             // This is a strike counter, hence we need to disable ECC integrity for this to work.
             // Integrity is handled at a higher level by SW as described below.
-            integrity:  false,
-            bkout_type: false,
+            integrity:    false,
+            bkout_type:   false,
+            lc_state_idx: 17,
             items: [
                 {
                     name: "CPTRA_CORE_FMC_KEY_MANIFEST_SVN",
@@ -400,17 +409,18 @@
             '''
         },
         {
-            name:       "VENDOR_TEST_PARTITION",
-            variant:    "Unbuffered",
-            size:       "64", // in bytes
-            secret:     false,
-            sw_digest:  true,
-            hw_digest:  false,
-            write_lock: "Digest",
-            read_lock:  "CSR",
-            key_sel:    "NoKey",
-            integrity:  false, // Do not use integrity (ECC) on this partition.
-            bkout_type: false, // Do not generate a breakout type for this partition.
+            name:         "VENDOR_TEST_PARTITION",
+            variant:      "Unbuffered",
+            size:         "64", // in bytes
+            secret:       false,
+            sw_digest:    true,
+            hw_digest:    false,
+            write_lock:   "Digest",
+            read_lock:    "CSR",
+            key_sel:      "NoKey",
+            integrity:    false, // Do not use integrity (ECC) on this partition.
+            bkout_type:   false, // Do not generate a breakout type for this partition.
+            lc_state_idx: 17,
             items: [
                 {
                     name: "VENDOR_TEST",
@@ -425,16 +435,17 @@
             '''
         },
         {
-            name:       "VENDOR_HASHES_MANUF_PARTITION",
-            variant:    "Unbuffered",
-            secret:     false,
-            sw_digest:  true,
-            hw_digest:  false,
-            write_lock: "Digest",
-            read_lock:  "CSR",
-            key_sel:    "NoKey",
-            integrity:  false, // Do not use integrity (ECC) on this partition.
-            bkout_type: false, // Do not generate a breakout type for this partition.
+            name:         "VENDOR_HASHES_MANUF_PARTITION",
+            variant:      "Unbuffered",
+            secret:       false,
+            sw_digest:    true,
+            hw_digest:    false,
+            write_lock:   "Digest",
+            read_lock:    "CSR",
+            key_sel:      "NoKey",
+            integrity:    false, // Do not use integrity (ECC) on this partition.
+            bkout_type:   false, // Do not generate a breakout type for this partition.
+            lc_state_idx: 17,
             items: [
                 {
                     name: "CPTRA_CORE_VENDOR_PK_HASH_0",
@@ -455,16 +466,17 @@
             '''
         },
         {
-            name:       "VENDOR_HASHES_PROD_PARTITION",
-            variant:    "Unbuffered",
-            secret:     false,
-            sw_digest:  true,
-            hw_digest:  false,
-            write_lock: "Digest",
-            read_lock:  "CSR",
-            key_sel:    "NoKey",
-            integrity:  false, // Do not use integrity (ECC) on this partition.
-            bkout_type: false, // Do not generate a breakout type for this partition.
+            name:         "VENDOR_HASHES_PROD_PARTITION",
+            variant:      "Unbuffered",
+            secret:       false,
+            sw_digest:    true,
+            hw_digest:    false,
+            write_lock:   "Digest",
+            read_lock:    "CSR",
+            key_sel:      "NoKey",
+            integrity:    false, // Do not use integrity (ECC) on this partition.
+            bkout_type:   false, // Do not generate a breakout type for this partition.
+            lc_state_idx: 17,
             items: [    
                 {
                     name: "CPTRA_CORE_VENDOR_PK_HASH_1",
@@ -689,16 +701,17 @@
             '''
         },
         {
-            name:       "VENDOR_REVOCATIONS_PROD_PARTITION",
-            variant:    "Unbuffered",
-            secret:     false,
-            sw_digest:  true,
-            hw_digest:  false,
-            write_lock: "Digest",
-            read_lock:  "CSR",
-            key_sel:    "NoKey",
-            integrity:  false, // Do not use integrity (ECC) on this partition.
-            bkout_type: false, // Do not generate a breakout type for this partition.
+            name:         "VENDOR_REVOCATIONS_PROD_PARTITION",
+            variant:      "Unbuffered",
+            secret:       false,
+            sw_digest:    true,
+            hw_digest:    false,
+            write_lock:   "Digest",
+            read_lock:    "CSR",
+            key_sel:      "NoKey",
+            integrity:    false, // Do not use integrity (ECC) on this partition.
+            bkout_type:   false, // Do not generate a breakout type for this partition.
+            lc_state_idx: 17,
             items: [
                 {
                     name:   "CPTRA_CORE_ECC_REVOCATION_0",
@@ -1041,16 +1054,17 @@
             '''
         },
         {
-            name:       "VENDOR_SECRET_PROD_PARTITION",
-            variant:    "Buffered",
-            secret:     true,
-            sw_digest:  false,
-            hw_digest:  true,
-            write_lock: "Digest",
-            read_lock:  "Digest",
-            key_sel:    "VendorSecretProdKey",
-            integrity:  true,
-            bkout_type: true,
+            name:         "VENDOR_SECRET_PROD_PARTITION",
+            variant:      "Buffered",
+            secret:       true,
+            sw_digest:    false,
+            hw_digest:    true,
+            write_lock:   "Digest",
+            read_lock:    "Digest",
+            key_sel:      "VendorSecretProdKey",
+            integrity:    true,
+            bkout_type:   true,
+            lc_state_idx: 17,
             items: [
                 {
                     name: "CPTRA_SS_VENDOR_SPECIFIC_SECRET_FUSE_0",
@@ -1169,17 +1183,18 @@
             '''
         },
         {
-            name:       "VENDOR_NON_SECRET_PROD_PARTITION",
-            variant:    "Unbuffered",
-            absorb:     true,
-            secret:     false,
-            sw_digest:  true,
-            hw_digest:  false,
-            write_lock: "Digest",
-            read_lock:  "CSR",
-            key_sel:    "NoKey",
-            integrity:  true,
-            bkout_type: false,
+            name:         "VENDOR_NON_SECRET_PROD_PARTITION",
+            variant:      "Unbuffered",
+            absorb:       true,
+            secret:       false,
+            sw_digest:    true,
+            hw_digest:    false,
+            write_lock:   "Digest",
+            read_lock:    "CSR",
+            key_sel:      "NoKey",
+            integrity:    true,
+            bkout_type:   false,
+            lc_state_idx: 17,
             items: [
                {
                     name: "CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_0",
@@ -1282,16 +1297,17 @@
             '''
         },
         {
-            name:       "LIFE_CYCLE",
-            variant:    "LifeCycle",
-            secret:     false,
-            sw_digest:  false,
-            hw_digest:  false,
-            write_lock: "None",
-            read_lock:  "None",
-            key_sel:    "NoKey",
-            integrity:  true,
-            bkout_type: false,
+            name:         "LIFE_CYCLE",
+            variant:      "LifeCycle",
+            secret:       false,
+            sw_digest:    false,
+            hw_digest:    false,
+            write_lock:   "None",
+            read_lock:    "None",
+            key_sel:      "NoKey",
+            integrity:    true,
+            bkout_type:   false,
+            lc_state_idx: 0,
             items: [
                 // The life cycle transition count is specified
                 // first such that any programming attempt of the life cycle

--- a/src/fuse_ctrl/rtl/otp_ctrl_part_pkg.sv
+++ b/src/fuse_ctrl/rtl/otp_ctrl_part_pkg.sv
@@ -112,6 +112,9 @@ package otp_ctrl_part_pkg;
     logic integrity;        // Whether the partition is integrity protected
     logic iskeymgr_creator; // Whether the partition has any creator key material
     logic iskeymgr_owner;   // Whether the partition has any owner key material
+    // Decoded LC state index. A partition can be written as long this index is
+    // smaller or equal the current state index of the LC (see `dec_lc_state_e`).
+    int lc_state_idx;
   } part_info_t;
 
   parameter part_info_t PartInfoDefault = '{
@@ -126,7 +129,8 @@ package otp_ctrl_part_pkg;
       read_lock:        1'b0,
       integrity:        1'b0,
       iskeymgr_creator: 1'b0,
-      iskeymgr_owner:   1'b0
+      iskeymgr_owner:   1'b0,
+      lc_state_idx:     0
   };
 
   ////////////////////////
@@ -147,7 +151,8 @@ package otp_ctrl_part_pkg;
       read_lock:        1'b1,
       integrity:        1'b1,
       iskeymgr_creator: 1'b0,
-      iskeymgr_owner:   1'b0
+      iskeymgr_owner:   1'b0,
+      lc_state_idx:     16
     },
     // SECRET_MANUF_PARTITION
     '{
@@ -162,7 +167,8 @@ package otp_ctrl_part_pkg;
       read_lock:        1'b1,
       integrity:        1'b1,
       iskeymgr_creator: 1'b0,
-      iskeymgr_owner:   1'b0
+      iskeymgr_owner:   1'b0,
+      lc_state_idx:     16
     },
     // SECRET_PROD_PARTITION_0
     '{
@@ -177,7 +183,8 @@ package otp_ctrl_part_pkg;
       read_lock:        1'b1,
       integrity:        1'b1,
       iskeymgr_creator: 1'b0,
-      iskeymgr_owner:   1'b0
+      iskeymgr_owner:   1'b0,
+      lc_state_idx:     17
     },
     // SECRET_PROD_PARTITION_1
     '{
@@ -192,7 +199,8 @@ package otp_ctrl_part_pkg;
       read_lock:        1'b1,
       integrity:        1'b1,
       iskeymgr_creator: 1'b0,
-      iskeymgr_owner:   1'b0
+      iskeymgr_owner:   1'b0,
+      lc_state_idx:     17
     },
     // SECRET_PROD_PARTITION_2
     '{
@@ -207,7 +215,8 @@ package otp_ctrl_part_pkg;
       read_lock:        1'b1,
       integrity:        1'b1,
       iskeymgr_creator: 1'b0,
-      iskeymgr_owner:   1'b0
+      iskeymgr_owner:   1'b0,
+      lc_state_idx:     17
     },
     // SECRET_PROD_PARTITION_3
     '{
@@ -222,7 +231,8 @@ package otp_ctrl_part_pkg;
       read_lock:        1'b1,
       integrity:        1'b1,
       iskeymgr_creator: 1'b0,
-      iskeymgr_owner:   1'b0
+      iskeymgr_owner:   1'b0,
+      lc_state_idx:     17
     },
     // SW_MANUF_PARTITION
     '{
@@ -237,7 +247,8 @@ package otp_ctrl_part_pkg;
       read_lock:        1'b0,
       integrity:        1'b1,
       iskeymgr_creator: 1'b0,
-      iskeymgr_owner:   1'b0
+      iskeymgr_owner:   1'b0,
+      lc_state_idx:     16
     },
     // SECRET_LC_TRANSITION_PARTITION
     '{
@@ -252,7 +263,8 @@ package otp_ctrl_part_pkg;
       read_lock:        1'b1,
       integrity:        1'b1,
       iskeymgr_creator: 1'b0,
-      iskeymgr_owner:   1'b0
+      iskeymgr_owner:   1'b0,
+      lc_state_idx:     16
     },
     // SVN_PARTITION
     '{
@@ -267,7 +279,8 @@ package otp_ctrl_part_pkg;
       read_lock:        1'b0,
       integrity:        1'b0,
       iskeymgr_creator: 1'b0,
-      iskeymgr_owner:   1'b0
+      iskeymgr_owner:   1'b0,
+      lc_state_idx:     17
     },
     // VENDOR_TEST_PARTITION
     '{
@@ -282,7 +295,8 @@ package otp_ctrl_part_pkg;
       read_lock:        1'b0,
       integrity:        1'b0,
       iskeymgr_creator: 1'b0,
-      iskeymgr_owner:   1'b0
+      iskeymgr_owner:   1'b0,
+      lc_state_idx:     17
     },
     // VENDOR_HASHES_MANUF_PARTITION
     '{
@@ -297,7 +311,8 @@ package otp_ctrl_part_pkg;
       read_lock:        1'b0,
       integrity:        1'b0,
       iskeymgr_creator: 1'b0,
-      iskeymgr_owner:   1'b0
+      iskeymgr_owner:   1'b0,
+      lc_state_idx:     17
     },
     // VENDOR_HASHES_PROD_PARTITION
     '{
@@ -312,7 +327,8 @@ package otp_ctrl_part_pkg;
       read_lock:        1'b0,
       integrity:        1'b0,
       iskeymgr_creator: 1'b0,
-      iskeymgr_owner:   1'b0
+      iskeymgr_owner:   1'b0,
+      lc_state_idx:     17
     },
     // VENDOR_REVOCATIONS_PROD_PARTITION
     '{
@@ -327,7 +343,8 @@ package otp_ctrl_part_pkg;
       read_lock:        1'b0,
       integrity:        1'b0,
       iskeymgr_creator: 1'b0,
-      iskeymgr_owner:   1'b0
+      iskeymgr_owner:   1'b0,
+      lc_state_idx:     17
     },
     // VENDOR_SECRET_PROD_PARTITION
     '{
@@ -342,7 +359,8 @@ package otp_ctrl_part_pkg;
       read_lock:        1'b1,
       integrity:        1'b1,
       iskeymgr_creator: 1'b0,
-      iskeymgr_owner:   1'b0
+      iskeymgr_owner:   1'b0,
+      lc_state_idx:     17
     },
     // VENDOR_NON_SECRET_PROD_PARTITION
     '{
@@ -357,7 +375,8 @@ package otp_ctrl_part_pkg;
       read_lock:        1'b0,
       integrity:        1'b1,
       iskeymgr_creator: 1'b0,
-      iskeymgr_owner:   1'b0
+      iskeymgr_owner:   1'b0,
+      lc_state_idx:     17
     },
     // LIFE_CYCLE
     '{
@@ -372,7 +391,8 @@ package otp_ctrl_part_pkg;
       read_lock:        1'b0,
       integrity:        1'b1,
       iskeymgr_creator: 1'b0,
-      iskeymgr_owner:   1'b0
+      iskeymgr_owner:   1'b0,
+      lc_state_idx:     0
     }
   };
 

--- a/src/fuse_ctrl/templates/otp_ctrl_mmap.hjson.tpl
+++ b/src/fuse_ctrl/templates/otp_ctrl_mmap.hjson.tpl
@@ -70,16 +70,17 @@
     // Note that the digest items are added automatically to the address map.
     partitions: [
         {
-            name:       "SECRET_TEST_UNLOCK_PARTITION",
-            variant:    "Buffered",
-            secret:     true,
-            sw_digest:  false,
-            hw_digest:  true,
-            write_lock: "Digest",
-            read_lock:  "Digest",
-            key_sel:    "SecretTestUnlockKey",
-            integrity:  true,
-            bkout_type: true,
+            name:         "SECRET_TEST_UNLOCK_PARTITION",
+            variant:      "Buffered",
+            secret:       true,
+            sw_digest:    false,
+            hw_digest:    true,
+            write_lock:   "Digest",
+            read_lock:    "Digest",
+            key_sel:      "SecretTestUnlockKey",
+            integrity:    true,
+            bkout_type:   true,
+            lc_state_idx: 16,
             items: [
                 {
                     name: "CPTRA_CORE_MANUF_DEBUG_UNLOCK_TOKEN",
@@ -93,16 +94,17 @@
             '''
         },
         {
-            name:       "SECRET_MANUF_PARTITION",
-            variant:    "Buffered",
-            secret:     true,
-            sw_digest:  false,
-            hw_digest:  true,
-            write_lock: "Digest",
-            read_lock:  "Digest",
-            key_sel:    "SecretManufKey",
-            integrity:  true,
-            bkout_type: true,
+            name:         "SECRET_MANUF_PARTITION",
+            variant:      "Buffered",
+            secret:       true,
+            sw_digest:    false,
+            hw_digest:    true,
+            write_lock:   "Digest",
+            read_lock:    "Digest",
+            key_sel:      "SecretManufKey",
+            integrity:    true,
+            bkout_type:   true,
+            lc_state_idx: 16,
             items: [
                 {
                     name: "CPTRA_CORE_UDS_SEED",
@@ -118,16 +120,17 @@
             '''
         },
         {
-            name:       "SECRET_PROD_PARTITION_0",
-            variant:    "Buffered",
-            secret:     true,
-            sw_digest:  false,
-            hw_digest:  true,
-            write_lock: "Digest",
-            read_lock:  "Digest",
-            key_sel:    "SecretProdKey0",
-            integrity:  true,
-            bkout_type: true,
+            name:         "SECRET_PROD_PARTITION_0",
+            variant:      "Buffered",
+            secret:       true,
+            sw_digest:    false,
+            hw_digest:    true,
+            write_lock:   "Digest",
+            read_lock:    "Digest",
+            key_sel:      "SecretProdKey0",
+            integrity:    true,
+            bkout_type:   true,
+            lc_state_idx: 17,
             items: [
                 {
                     name: "CPTRA_CORE_FIELD_ENTROPY_0",
@@ -143,16 +146,17 @@
             '''
         },
         {
-            name:       "SECRET_PROD_PARTITION_1",
-            variant:    "Buffered",
-            secret:     true,
-            sw_digest:  false,
-            hw_digest:  true,
-            write_lock: "Digest",
-            read_lock:  "Digest",
-            key_sel:    "SecretProdKey1",
-            integrity:  true,
-            bkout_type: true,
+            name:         "SECRET_PROD_PARTITION_1",
+            variant:      "Buffered",
+            secret:       true,
+            sw_digest:    false,
+            hw_digest:    true,
+            write_lock:   "Digest",
+            read_lock:    "Digest",
+            key_sel:      "SecretProdKey1",
+            integrity:    true,
+            bkout_type:   true,
+            lc_state_idx: 17,
             items: [
                 {
                     name: "CPTRA_CORE_FIELD_ENTROPY_1",
@@ -168,16 +172,17 @@
             '''
         },
         {
-            name:       "SECRET_PROD_PARTITION_2",
-            variant:    "Buffered",
-            secret:     true,
-            sw_digest:  false,
-            hw_digest:  true,
-            write_lock: "Digest",
-            read_lock:  "Digest",
-            key_sel:    "SecretProdKey2",
-            integrity:  true,
-            bkout_type: true,
+            name:         "SECRET_PROD_PARTITION_2",
+            variant:      "Buffered",
+            secret:       true,
+            sw_digest:    false,
+            hw_digest:    true,
+            write_lock:   "Digest",
+            read_lock:    "Digest",
+            key_sel:      "SecretProdKey2",
+            integrity:    true,
+            bkout_type:   true,
+            lc_state_idx: 17,
             items: [
                 {
                     name: "CPTRA_CORE_FIELD_ENTROPY_2",
@@ -193,16 +198,17 @@
             '''
         },
         {
-            name:       "SECRET_PROD_PARTITION_3",
-            variant:    "Buffered",
-            secret:     true,
-            sw_digest:  false,
-            hw_digest:  true,
-            write_lock: "Digest",
-            read_lock:  "Digest",
-            key_sel:    "SecretProdKey3",
-            integrity:  true,
-            bkout_type: true,
+            name:         "SECRET_PROD_PARTITION_3",
+            variant:      "Buffered",
+            secret:       true,
+            sw_digest:    false,
+            hw_digest:    true,
+            write_lock:   "Digest",
+            read_lock:    "Digest",
+            key_sel:      "SecretProdKey3",
+            integrity:    true,
+            bkout_type:   true,
+            lc_state_idx: 17,
             items: [
                 {
                     name: "CPTRA_CORE_FIELD_ENTROPY_3",
@@ -218,17 +224,18 @@
             '''
         },
         {
-            name:       "SW_MANUF_PARTITION",
-            variant:    "Unbuffered",
-            absorb:     true,
-            secret:     false,
-            sw_digest:  true,
-            hw_digest:  false,
-            write_lock: "Digest",
-            read_lock:  "CSR",
-            key_sel:    "NoKey",
-            integrity:  true,
-            bkout_type: false,
+            name:         "SW_MANUF_PARTITION",
+            variant:      "Unbuffered",
+            absorb:       true,
+            secret:       false,
+            sw_digest:    true,
+            hw_digest:    false,
+            write_lock:   "Digest",
+            read_lock:    "CSR",
+            key_sel:      "NoKey",
+            integrity:    true,
+            bkout_type:   false,
+            lc_state_idx: 16,
             items: [
                 {
                     name: "CPTRA_CORE_ANTI_ROLLBACK_DISABLE",
@@ -275,16 +282,17 @@
             '''
         },
         {
-            name:       "SECRET_LC_TRANSITION_PARTITION",
-            variant:    "Buffered",
-            secret:     true,
-            sw_digest:  false,
-            hw_digest:  true,
-            write_lock: "Digest",
-            read_lock:  "Digest",
-            key_sel:    "SecretLifeCycleTransitionKey",
-            integrity:  true,
-            bkout_type: false,
+            name:         "SECRET_LC_TRANSITION_PARTITION",
+            variant:      "Buffered",
+            secret:       true,
+            sw_digest:    false,
+            hw_digest:    true,
+            write_lock:   "Digest",
+            read_lock:    "Digest",
+            key_sel:      "SecretLifeCycleTransitionKey",
+            integrity:    true,
+            bkout_type:   false,
+            lc_state_idx: 16,
             items: [
                 {
                     name: "CPTRA_SS_TEST_UNLOCK_TOKEN_0",
@@ -355,19 +363,20 @@
             '''
         },
         {
-            name:       "SVN_PARTITION",
-            variant:    "Unbuffered",
-            absorb:     false,
-            secret:     false,
-            sw_digest:  false,
-            hw_digest:  false,
-            write_lock: "None",
-            read_lock:  "CSR",
-            key_sel:    "NoKey",
+            name:         "SVN_PARTITION",
+            variant:      "Unbuffered",
+            absorb:       false,
+            secret:       false,
+            sw_digest:    false,
+            hw_digest:    false,
+            write_lock:   "None",
+            read_lock:    "CSR",
+            key_sel:      "NoKey",
             // This is a strike counter, hence we need to disable ECC integrity for this to work.
             // Integrity is handled at a higher level by SW as described below.
-            integrity:  false,
-            bkout_type: false,
+            integrity:    false,
+            bkout_type:   false,
+            lc_state_idx: 17,
             items: [
                 {
                     name: "CPTRA_CORE_FMC_KEY_MANIFEST_SVN",
@@ -402,17 +411,18 @@
             '''
         },
         {
-            name:       "VENDOR_TEST_PARTITION",
-            variant:    "Unbuffered",
-            size:       "64", // in bytes
-            secret:     false,
-            sw_digest:  true,
-            hw_digest:  false,
-            write_lock: "Digest",
-            read_lock:  "CSR",
-            key_sel:    "NoKey",
-            integrity:  false, // Do not use integrity (ECC) on this partition.
-            bkout_type: false, // Do not generate a breakout type for this partition.
+            name:         "VENDOR_TEST_PARTITION",
+            variant:      "Unbuffered",
+            size:         "64", // in bytes
+            secret:       false,
+            sw_digest:    true,
+            hw_digest:    false,
+            write_lock:   "Digest",
+            read_lock:    "CSR",
+            key_sel:      "NoKey",
+            integrity:    false, // Do not use integrity (ECC) on this partition.
+            bkout_type:   false, // Do not generate a breakout type for this partition.
+            lc_state_idx: 17,
             items: [
                 {
                     name: "VENDOR_TEST",
@@ -431,16 +441,17 @@
 #############################################################
 % if num_vendor_pk_fuses > 0:
         {
-            name:       "VENDOR_HASHES_MANUF_PARTITION",
-            variant:    "Unbuffered",
-            secret:     false,
-            sw_digest:  true,
-            hw_digest:  false,
-            write_lock: "Digest",
-            read_lock:  "CSR",
-            key_sel:    "NoKey",
-            integrity:  false, // Do not use integrity (ECC) on this partition.
-            bkout_type: false, // Do not generate a breakout type for this partition.
+            name:         "VENDOR_HASHES_MANUF_PARTITION",
+            variant:      "Unbuffered",
+            secret:       false,
+            sw_digest:    true,
+            hw_digest:    false,
+            write_lock:   "Digest",
+            read_lock:    "CSR",
+            key_sel:      "NoKey",
+            integrity:    false, // Do not use integrity (ECC) on this partition.
+            bkout_type:   false, // Do not generate a breakout type for this partition.
+            lc_state_idx: 17,
             items: [
                 {
                     name: "CPTRA_CORE_VENDOR_PK_HASH_0",
@@ -461,16 +472,17 @@
             '''
         },
         {
-            name:       "VENDOR_HASHES_PROD_PARTITION",
-            variant:    "Unbuffered",
-            secret:     false,
-            sw_digest:  true,
-            hw_digest:  false,
-            write_lock: "Digest",
-            read_lock:  "CSR",
-            key_sel:    "NoKey",
-            integrity:  false, // Do not use integrity (ECC) on this partition.
-            bkout_type: false, // Do not generate a breakout type for this partition.
+            name:         "VENDOR_HASHES_PROD_PARTITION",
+            variant:      "Unbuffered",
+            secret:       false,
+            sw_digest:    true,
+            hw_digest:    false,
+            write_lock:   "Digest",
+            read_lock:    "CSR",
+            key_sel:      "NoKey",
+            integrity:    false, // Do not use integrity (ECC) on this partition.
+            bkout_type:   false, // Do not generate a breakout type for this partition.
+            lc_state_idx: 17,
             items: [    
     % for i in range(1, num_vendor_pk_fuses):               
                 {
@@ -501,16 +513,17 @@
             '''
         },
         {
-            name:       "VENDOR_REVOCATIONS_PROD_PARTITION",
-            variant:    "Unbuffered",
-            secret:     false,
-            sw_digest:  true,
-            hw_digest:  false,
-            write_lock: "Digest",
-            read_lock:  "CSR",
-            key_sel:    "NoKey",
-            integrity:  false, // Do not use integrity (ECC) on this partition.
-            bkout_type: false, // Do not generate a breakout type for this partition.
+            name:         "VENDOR_REVOCATIONS_PROD_PARTITION",
+            variant:      "Unbuffered",
+            secret:       false,
+            sw_digest:    true,
+            hw_digest:    false,
+            write_lock:   "Digest",
+            read_lock:    "CSR",
+            key_sel:      "NoKey",
+            integrity:    false, // Do not use integrity (ECC) on this partition.
+            bkout_type:   false, // Do not generate a breakout type for this partition.
+            lc_state_idx: 17,
             items: [
     % for i in range(num_vendor_pk_fuses):  
                 {
@@ -542,16 +555,17 @@
 % endif
 % if num_vendor_secret_fuses > 0:
         {
-            name:       "VENDOR_SECRET_PROD_PARTITION",
-            variant:    "Buffered",
-            secret:     true,
-            sw_digest:  false,
-            hw_digest:  true,
-            write_lock: "Digest",
-            read_lock:  "Digest",
-            key_sel:    "VendorSecretProdKey",
-            integrity:  true,
-            bkout_type: true,
+            name:         "VENDOR_SECRET_PROD_PARTITION",
+            variant:      "Buffered",
+            secret:       true,
+            sw_digest:    false,
+            hw_digest:    true,
+            write_lock:   "Digest",
+            read_lock:    "Digest",
+            key_sel:      "VendorSecretProdKey",
+            integrity:    true,
+            bkout_type:   true,
+            lc_state_idx: 17,
             items: [
     % for i in range(num_vendor_secret_fuses):
                 {
@@ -569,17 +583,18 @@
 % endif
 % if num_vendor_non_secret_fuses > 0:
         {
-            name:       "VENDOR_NON_SECRET_PROD_PARTITION",
-            variant:    "Unbuffered",
-            absorb:     true,
-            secret:     false,
-            sw_digest:  true,
-            hw_digest:  false,
-            write_lock: "Digest",
-            read_lock:  "CSR",
-            key_sel:    "NoKey",
-            integrity:  true,
-            bkout_type: false,
+            name:         "VENDOR_NON_SECRET_PROD_PARTITION",
+            variant:      "Unbuffered",
+            absorb:       true,
+            secret:       false,
+            sw_digest:    true,
+            hw_digest:    false,
+            write_lock:   "Digest",
+            read_lock:    "CSR",
+            key_sel:      "NoKey",
+            integrity:    true,
+            bkout_type:   false,
+            lc_state_idx: 17,
             items: [
     % for i in range(num_vendor_non_secret_fuses):
                {
@@ -598,16 +613,17 @@
 ## End vendor-specific fuses
 #############################################################      
         {
-            name:       "LIFE_CYCLE",
-            variant:    "LifeCycle",
-            secret:     false,
-            sw_digest:  false,
-            hw_digest:  false,
-            write_lock: "None",
-            read_lock:  "None",
-            key_sel:    "NoKey",
-            integrity:  true,
-            bkout_type: false,
+            name:         "LIFE_CYCLE",
+            variant:      "LifeCycle",
+            secret:       false,
+            sw_digest:    false,
+            hw_digest:    false,
+            write_lock:   "None",
+            read_lock:    "None",
+            key_sel:      "NoKey",
+            integrity:    true,
+            bkout_type:   false,
+            lc_state_idx: 0,
             items: [
                 // The life cycle transition count is specified
                 // first such that any programming attempt of the life cycle

--- a/src/fuse_ctrl/templates/otp_ctrl_part_pkg.sv.tpl
+++ b/src/fuse_ctrl/templates/otp_ctrl_part_pkg.sv.tpl
@@ -113,6 +113,9 @@ package otp_ctrl_part_pkg;
     logic integrity;        // Whether the partition is integrity protected
     logic iskeymgr_creator; // Whether the partition has any creator key material
     logic iskeymgr_owner;   // Whether the partition has any owner key material
+    // Decoded LC state index. A partition can be written as long this index is
+    // smaller or equal the current state index of the LC (see `dec_lc_state_e`).
+    int lc_state_idx;
   } part_info_t;
 
   parameter part_info_t PartInfoDefault = '{
@@ -127,7 +130,8 @@ package otp_ctrl_part_pkg;
       read_lock:        1'b0,
       integrity:        1'b0,
       iskeymgr_creator: 1'b0,
-      iskeymgr_owner:   1'b0
+      iskeymgr_owner:   1'b0,
+      lc_state_idx:     0
   };
 
   ////////////////////////
@@ -149,7 +153,8 @@ package otp_ctrl_part_pkg;
       read_lock:        1'b${"1" if part["read_lock"].lower() == "digest" else "0"},
       integrity:        1'b${"1" if part["integrity"] else "0"},
       iskeymgr_creator: 1'b${"1" if part["iskeymgr_creator"] else "0"},
-      iskeymgr_owner:   1'b${"1" if part["iskeymgr_owner"] else "0"}
+      iskeymgr_owner:   1'b${"1" if part["iskeymgr_owner"] else "0"},
+      lc_state_idx:     ${part["lc_state_idx"]}
     }${"" if loop.last else ","}
 % endfor
   };


### PR DESCRIPTION
Make sure that partitions cannot be written in the Raw state and that MANUF and PROD partitions can only be provisioned up to their respective LC states.