### PR TITLE
Add MCU MBOX Tests and Fix MBOX Lock Clearing Detection

### DIFF
--- a/docs/CaliptraSSHardwareSpecification.md
+++ b/docs/CaliptraSSHardwareSpecification.md
@@ -31,6 +31,11 @@
   - [Caliptra ROM Requirements](#caliptra-rom-requirements)
   - [I3C and Caliptra-AXI Interactions](#i3c-and-caliptra-axi-interactions)
 - [Caliptra AXI Manager \& DMA assist](#caliptra-axi-manager--dma-assist)
+  - [AXI Feature Support](#axi-feature-support)
+  - [Routes](#routes)
+  - [Streaming Boot Payloads](#streaming-boot-payloads)
+  - [Programming Flowchart {#programming-flowchart}](#programming-flowchart-programming-flowchart)
+  - [Descriptor](#descriptor)
 - [Caliptra SS Fuse Controller](#caliptra-ss-fuse-controller)
   - [Partition Details](#partition-details)
     - [Key Characteristics of Secret Partitions:](#key-characteristics-of-secret-partitions)
@@ -1136,7 +1141,7 @@ A Requester will read the "LOCK" register to obtain a lock on the mailbox. This 
   -  TARGET_DONE
   -  TARGET_USER
 - Mailbox SRAM
-Unlocking occurs when the requestor clears the execution register. After releasing the mailbox the SRAM is zeroed out ([MCU Mailbox SRAM Clearing](#mcu-mailbox-sram-clearing)).
+Unlocking/releasing occurs when the requestor writes 0 to the EXECUTE register. After releasing the mailbox the SRAM is zeroed out([MCU Mailbox SRAM Clearing](#mcu-mailbox-sram-clearing)).
 
 On MCI reset release the MCU MBOX is locked for MCU. The MCU shall set the DLEN to the size of the SRAM and release the MBOX, causing the SRAM to be zeroed. This is done to prevent data leaking between warm resets via the SRAM. 
 
@@ -1180,7 +1185,7 @@ If set to 0 the mailbox is not instantiated.
 
 When the mailbox lock is released the SRAM is zeroed out from 0 to max DLEN set during the locking period. The flow for clearing the SRAM is:
 
-1. Requester releases lock by clearing the EXECUTE register
+1. Requester releases lock
 2. MCU SRAM starts clearing
 3. MCU SRAM clearing ends
 4. Mailbox is unlocked

--- a/src/integration/stimulus/L0_Promote_caliptra_ss_top_tb_regression.yml
+++ b/src/integration/stimulus/L0_Promote_caliptra_ss_top_tb_regression.yml
@@ -11,3 +11,6 @@ contents:
         - ../test_suites/smoke_test_fc_prov_lcc_tokens/smoke_test_fc_prov_lcc_tokens.yml
         - ../test_suites/smoke_test_fc_random_item_prov/smoke_test_fc_random_item_prov.yml
         - ../test_suites/smoke_test_fc_registers/smoke_test_fc_registers.yml
+        - ../test_suites/smoke_test_mcu_mbox/smoke_test_mcu_mbox.yml
+        - ../test_suites/smoke_test_mcu_mbox_zeroize/smoke_test_mcu_mbox_zeroize.yml
+        - ../test_suites/mcu_mbox_lock_return_one_during_zeroize/mcu_mbox_lock_return_one_during_zeroize.yml

--- a/src/integration/stimulus/L0_Promote_caliptra_ss_top_tb_regression.yml
+++ b/src/integration/stimulus/L0_Promote_caliptra_ss_top_tb_regression.yml
@@ -14,3 +14,4 @@ contents:
         - ../test_suites/smoke_test_mcu_mbox/smoke_test_mcu_mbox.yml
         - ../test_suites/smoke_test_mcu_mbox_zeroize/smoke_test_mcu_mbox_zeroize.yml
         - ../test_suites/mcu_mbox_lock_return_one_during_zeroize/mcu_mbox_lock_return_one_during_zeroize.yml
+        - ../test_suites/smoke_test_mbox_csr_zeros_after_release/smoke_test_mbox_csr_zeros_after_release.yml

--- a/src/integration/stimulus/testsuites/caliptra_ss_master_test_list.csv
+++ b/src/integration/stimulus/testsuites/caliptra_ss_master_test_list.csv
@@ -17,3 +17,6 @@ $CALIPTRA_SS/src/integration/test_suites/mcu_lmem_exe/mcu_lmem_exe, Directed, Ni
 $CALIPTRA_SS/src/integration/test_suites/smoke_test_fuse_prov_with_axi_id/smoke_test_fuse_prov_with_axi_id, Directed, Nightly, None, L1, caliptra_ss_top_tb, None, None, 100
 $CALIPTRA_SS/src/integration/test_suites/smoke_test_fuse_zeroize/smoke_test_fuse_zeroize, Directed, Nightly, None, L1, caliptra_ss_top_tb, None, None, 100
 $CALIPTRA_SS/src/integration/test_suites/smoke_test_lcc_scrap/smoke_test_lcc_scrap, Directed, Nightly, None, L1, caliptra_ss_top_tb, None, None, 100
+$CALIPTRA_SS/src/integration/test_suites/smoke_test_mcu_mbox/smoke_test_mcu_mbox, None, None, L0, None, caliptra_ss_top_tb, Promote, None, 100
+$CALIPTRA_SS/src/integration/test_suites/smoke_test_mcu_mbox_zeroize/smoke_test_mcu_mbox_zeroize, None, None, L0, None, caliptra_ss_top_tb, Promote, None, 100
+$CALIPTRA_SS/src/integration/test_suites/mcu_mbox_lock_return_one_during_zeroize/mcu_mbox_lock_return_one_during_zeroize, None, None, L0, None, caliptra_ss_top_tb, Promote, None, 100

--- a/src/integration/stimulus/testsuites/caliptra_ss_master_test_list.csv
+++ b/src/integration/stimulus/testsuites/caliptra_ss_master_test_list.csv
@@ -20,3 +20,4 @@ $CALIPTRA_SS/src/integration/test_suites/smoke_test_lcc_scrap/smoke_test_lcc_scr
 $CALIPTRA_SS/src/integration/test_suites/smoke_test_mcu_mbox/smoke_test_mcu_mbox, None, None, L0, None, caliptra_ss_top_tb, Promote, None, 100
 $CALIPTRA_SS/src/integration/test_suites/smoke_test_mcu_mbox_zeroize/smoke_test_mcu_mbox_zeroize, None, None, L0, None, caliptra_ss_top_tb, Promote, None, 100
 $CALIPTRA_SS/src/integration/test_suites/mcu_mbox_lock_return_one_during_zeroize/mcu_mbox_lock_return_one_during_zeroize, None, None, L0, None, caliptra_ss_top_tb, Promote, None, 100
+$CALIPTRA_SS/src/integration/test_suites/smoke_test_mbox_csr_zeros_after_release/smoke_test_mbox_csr_zeros_after_release, None, None, L0, None, caliptra_ss_top_tb, Promote, None, 100

--- a/src/integration/test_suites/libs/caliptra_ss_lib/caliptra_ss_lib.c
+++ b/src/integration/test_suites/libs/caliptra_ss_lib/caliptra_ss_lib.c
@@ -81,6 +81,17 @@ void mcu_cptra_user_init() {
 
 }
 
+void mcu_mbox_clear_lock_out_of_reset() {
+    // MBOX: Write DLEN  (normally would be max SRAM size but using smaller size for test run time)
+    lsu_write_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_DLEN, 32);
+
+    // MBOX: Clear Execute
+    lsu_write_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_EXECUTE, 0);
+    VPRINTF(LOW, "MCU: Mbox0 execute clear\n");
+    
+    VPRINTF(LOW, "MCU: MBOX Lock out of reset cleared\n");
+}
+
 void mcu_cptra_poll_mb_ready() {
     // MBOX: Wait for ready_for_mb_processing
     while(!(lsu_read_32(SOC_SOC_IFC_REG_CPTRA_FLOW_STATUS) & SOC_IFC_REG_CPTRA_FLOW_STATUS_READY_FOR_MB_PROCESSING_MASK)) {

--- a/src/integration/test_suites/libs/caliptra_ss_lib/caliptra_ss_lib.h
+++ b/src/integration/test_suites/libs/caliptra_ss_lib/caliptra_ss_lib.h
@@ -23,5 +23,6 @@ void mcu_cptra_fuse_init();
 void mcu_cptra_user_init();
 void mcu_cptra_poll_mb_ready();
 void mcu_cptra_mbox_cmd();
+void mcu_mbox_clear_lock_out_of_reset();
 
 #endif // CALIPTRA_SS_LIB

--- a/src/integration/test_suites/mcu_mbox_lock_return_one_during_zeroize/mcu_mbox_lock_return_one_during_zeroize.c
+++ b/src/integration/test_suites/mcu_mbox_lock_return_one_during_zeroize/mcu_mbox_lock_return_one_during_zeroize.c
@@ -31,40 +31,26 @@ volatile char* stdout = (char *)SOC_MCI_TOP_MCI_REG_DEBUG_OUT;
     enum printf_verbosity verbosity_g = LOW;
 #endif
 
+
 void main (void) {
     int argc=0;
     char *argv[1];
     enum boot_fsm_state_e boot_fsm_ps;
-    const uint32_t mbox_dlen = 64;
-    uint32_t mbox_data[] = { 0x00000000,
-                             0x11111111,
-                             0x22222222,
-                             0x33333333,
-                             0x44444444,
-                             0x55555555,
-                             0x66666666,
-                             0x77777777,
-                             0x88888888,
-                             0x99999999,
-                             0xaaaaaaaa,
-                             0xbbbbbbbb,
-                             0xcccccccc,
-                             0xdddddddd,
-                             0xeeeeeeee,
-                             0xffffffff };
+    const uint32_t mbox_dlen = 10000; // Program to large value to make sure zeroization is still in progress when read of lock arrives
+
     uint32_t mbox_resp_dlen;
     uint32_t mbox_resp_data;
     uint32_t mci_boot_fsm_go;
     uint32_t sram_data;
 
     VPRINTF(LOW, "=================\nMCU: Subsytem Bringup Test\n=================\n\n")
-    mcu_mci_boot_go();
-    
+
+    mcu_mci_boot_go();    
 
     VPRINTF(LOW, "MCU: Caliptra bringup\n")
 
     mcu_cptra_fuse_init();
-
+    
     ////////////////////////////////////
     // Mailbox command test
     //
@@ -82,31 +68,7 @@ void main (void) {
     VPRINTF(LOW, "MCU: Mbox0 lock acquired\n");
     
     // MBOX: Write DLEN
-    lsu_write_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_DLEN, mbox_dlen/2);
-
-    // MBOX: Write SRAM
-    for (uint32_t ii = 0; ii < (mbox_dlen/2)/4; ii++) {
-        lsu_write_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_SRAM_BASE_ADDR+(4*ii), mbox_data[ii]);
-    }
-
-    // MBOX: Write DLEN again to simulate increasing the max dlen while lock is in place
     lsu_write_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_DLEN, mbox_dlen);
-
-    // MBOX: Write SRAM
-    for (uint32_t ii = (mbox_dlen/2)/4; ii < mbox_dlen/4; ii++) {
-        lsu_write_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_SRAM_BASE_ADDR+(4*ii), mbox_data[ii]);
-    }
-    VPRINTF(LOW, "MCU: Write data to Mbox0\n");
-
-    // MBOX: check that some non-zero data has been written to beyond max_dlen/2
-    if(lsu_read_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_SRAM_BASE_ADDR+(mbox_dlen/2)) == 0) {
-        VPRINTF(FATAL, "MCU: Mbox0 should have valid non-zero data written here\n");
-        SEND_STDOUT_CTRL(0x1);
-        while(1);
-    }
-
-    // MBOX: Write DLEN again to simulate decreasing the dlen while lock is in place to ensure max is retained
-    lsu_write_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_DLEN, mbox_dlen/2);
 
     // MBOX: Execute
     lsu_write_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_EXECUTE, MCU_MBOX0_CSR_MBOX_EXECUTE_EXECUTE_MASK);
@@ -116,19 +78,13 @@ void main (void) {
     lsu_write_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_EXECUTE, 0);
     VPRINTF(LOW, "MCU: Mbox0 execute clear\n");
 
-    // MBOX: Re-acquire lock
-    while((lsu_read_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_LOCK) & MCU_MBOX0_CSR_MBOX_LOCK_LOCK_MASK));
-    VPRINTF(LOW, "MCU: Mbox0 lock acquired\n");
-
-    // MBOX: check that data has been zeroed
-    VPRINTF(LOW, "MCU: Checking that MCU Mbox0 up to max dlen had been zeroed \n");
-    for (uint32_t ii = 0; ii < mbox_dlen/4; ii++) {
-        if(lsu_read_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_SRAM_BASE_ADDR+(4*ii)) != 0) {
-            VPRINTF(FATAL, "MCU: Mbox0 SRAM data not zeroed out at dword: %x\n", ii);
-            SEND_STDOUT_CTRL(0x1);
-            while(1);
-        }
+    // MBOX: Check that lock returns 1 while zeroize in progress
+    if((lsu_read_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_LOCK) & MCU_MBOX0_CSR_MBOX_LOCK_LOCK_MASK) == 0) {
+        VPRINTF(FATAL, "MCU: Mbox0 lock should have returned one while zeroize in progress\n");
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
     }
+    VPRINTF(LOW, "MCU: Mbox0 lock returned 1 while zeroing\n");
 
     SEND_STDOUT_CTRL(0xff);
 }

--- a/src/integration/test_suites/mcu_mbox_lock_return_one_during_zeroize/mcu_mbox_lock_return_one_during_zeroize.yml
+++ b/src/integration/test_suites/mcu_mbox_lock_return_one_during_zeroize/mcu_mbox_lock_return_one_during_zeroize.yml
@@ -1,0 +1,7 @@
+---
+seed: 1
+testname: mcu_mbox_lock_return_one_during_zeroize
+pre-exec: |
+  echo "Running pre_exec for [mcu_mbox_lock_return_one_during_zeroize]"
+  CALIPTRA_ROOT=$CALIPTRA_SS_ROOT/third_party/caliptra-rtl make -f $CALIPTRA_SS_ROOT/third_party/caliptra-rtl/tools/scripts/Makefile CALIPTRA_INTERNAL_TRNG=0 TESTNAME=smoke_test_mbox program.hex
+  make -f $CALIPTRA_SS_ROOT/tools/scripts/Makefile TESTNAME=mcu_mbox_lock_return_one_during_zeroize mcu_program.hex

--- a/src/integration/test_suites/smoke_test_mbox_csr_zeros_after_release/smoke_test_mbox_csr_zeros_after_release.c
+++ b/src/integration/test_suites/smoke_test_mbox_csr_zeros_after_release/smoke_test_mbox_csr_zeros_after_release.c
@@ -1,0 +1,171 @@
+//********************************************************************************
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 Western Digital Corporation or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//********************************************************************************
+
+#include "soc_address_map.h"
+#include "printf.h"
+#include "riscv_hw_if.h"
+#include "soc_ifc.h"
+#include "caliptra_ss_lib.h"
+#include <string.h>
+#include <stdint.h>
+
+volatile char* stdout = (char *)SOC_MCI_TOP_MCI_REG_DEBUG_OUT;
+
+#ifdef CPT_VERBOSITY
+    enum printf_verbosity verbosity_g = CPT_VERBOSITY;
+#else
+    enum printf_verbosity verbosity_g = LOW;
+#endif
+
+
+void main (void) {
+    int argc=0;
+    char *argv[1];
+    enum boot_fsm_state_e boot_fsm_ps;
+
+    uint32_t mbox_resp_dlen;
+    uint32_t mbox_resp_data;
+    uint32_t mci_boot_fsm_go;
+    uint32_t sram_data;
+
+    VPRINTF(LOW, "=================\nMCU: Subsytem Bringup Test\n=================\n\n")
+
+    mcu_mci_boot_go();    
+
+    VPRINTF(LOW, "MCU: Caliptra bringup\n")
+
+    mcu_cptra_fuse_init();
+    
+    ////////////////////////////////////
+    // Mailbox command test
+    //
+
+    mcu_cptra_poll_mb_ready();
+    mcu_cptra_user_init();
+
+
+    VPRINTF(LOW, "=================\nMCU MBOX SRAM Testing\n=================\n\n")
+
+    // MBOX: Confim MCU already has lock out of reset
+    if((lsu_read_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_LOCK) & MCU_MBOX0_CSR_MBOX_LOCK_LOCK_MASK) == 0) {
+        VPRINTF(FATAL, "MCU: Mbox0 lock should already be locked\n");
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+
+    uint32_t mbox_dlen = 64;
+    uint32_t mbox_target_user = 8;
+    uint32_t mbox_target_user_valid = 1;
+    uint32_t mbox_cmd = 0xdead;
+    uint32_t mbox_target_status = 0x2;
+    uint32_t mbox_cmd_status = 0x1;
+
+    // Write CSRs
+    VPRINTF(LOW, "MCU: Mbox0 writing CSRs\n");
+    lsu_write_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_DLEN, mbox_dlen);
+
+    lsu_write_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_TARGET_USER, mbox_target_user);
+
+    lsu_write_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_TARGET_USER_VALID, mbox_target_user_valid);
+
+    lsu_write_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_CMD, mbox_cmd);
+    
+    lsu_write_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_TARGET_STATUS, mbox_target_status);
+
+    lsu_write_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_CMD_STATUS, mbox_cmd_status);
+
+    // MBOX: Confirm CSRs writes took affect
+    if(lsu_read_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_DLEN) != mbox_dlen) {
+        VPRINTF(FATAL, "MCU: Mbox0 DLEN write failed\n");
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+    if(lsu_read_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_TARGET_USER) != mbox_target_user) {
+        VPRINTF(FATAL, "MCU: Mbox0 Target User write failed\n");
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+    if(lsu_read_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_TARGET_USER_VALID) != mbox_target_user_valid) {
+        VPRINTF(FATAL, "MCU: Mbox0 Target User Valid write failed\n");
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+    if(lsu_read_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_CMD) != mbox_cmd) {
+        VPRINTF(FATAL, "MCU: Mbox0 Target User Valid write failed\n");
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+    if(lsu_read_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_TARGET_STATUS) != mbox_target_status) {
+        VPRINTF(FATAL, "MCU: Mbox0 Target User Valid write failed\n");
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+    if(lsu_read_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_CMD_STATUS) != mbox_cmd_status) {
+        VPRINTF(FATAL, "MCU: Mbox0 Target User Valid write failed\n");
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+
+    // MBOX: Execute
+    lsu_write_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_EXECUTE, MCU_MBOX0_CSR_MBOX_EXECUTE_EXECUTE_MASK);
+    VPRINTF(LOW, "MCU: Mbox0 execute\n");
+
+    // MBOX: Clear Execute
+    lsu_write_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_EXECUTE, 0);
+    VPRINTF(LOW, "MCU: Mbox0 execute clear\n");
+
+    // MBOX: Confirm CSRs are 0 after execute clear
+    if(lsu_read_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_DLEN) != 0) {
+        VPRINTF(FATAL, "MCU: Mbox0 DLEN should be 0\n");
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+    if(lsu_read_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_USER) != 0) {
+        VPRINTF(FATAL, "MCU: Mbox0 Mbox User should be 0\n");
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+    if(lsu_read_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_TARGET_USER) != 0) {
+        VPRINTF(FATAL, "MCU: Mbox0 Target User should be 0\n");
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+    if(lsu_read_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_TARGET_USER_VALID) != 0) {
+        VPRINTF(FATAL, "MCU: Mbox0 Target User Valid should be 0\n");
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+    if(lsu_read_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_CMD) != 0) {
+        VPRINTF(FATAL, "MCU: Mbox0 Target User Valid should be 0\n");
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+    if(lsu_read_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_TARGET_STATUS) != 0) {
+        VPRINTF(FATAL, "MCU: Mbox0 Target User Valid should be 0\n");
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+    if(lsu_read_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_CMD_STATUS) != 0) {
+        VPRINTF(FATAL, "MCU: Mbox0 Target User Valid should be 0\n");
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+
+    VPRINTF(LOW, "MCU: Mbox0 CRS are cleared\n");
+
+    SEND_STDOUT_CTRL(0xff);
+}

--- a/src/integration/test_suites/smoke_test_mbox_csr_zeros_after_release/smoke_test_mbox_csr_zeros_after_release.yml
+++ b/src/integration/test_suites/smoke_test_mbox_csr_zeros_after_release/smoke_test_mbox_csr_zeros_after_release.yml
@@ -1,0 +1,7 @@
+---
+seed: 1
+testname: smoke_test_mbox_csr_zeros_after_release
+pre-exec: |
+  echo "Running pre_exec for [smoke_test_mbox_csr_zeros_after_release]"
+  CALIPTRA_ROOT=$CALIPTRA_SS_ROOT/third_party/caliptra-rtl make -f $CALIPTRA_SS_ROOT/third_party/caliptra-rtl/tools/scripts/Makefile CALIPTRA_INTERNAL_TRNG=0 TESTNAME=smoke_test_mbox program.hex
+  make -f $CALIPTRA_SS_ROOT/tools/scripts/Makefile TESTNAME=smoke_test_mbox_csr_zeros_after_release mcu_program.hex

--- a/src/integration/test_suites/smoke_test_mcu_mbox/caliptra_isr.h
+++ b/src/integration/test_suites/smoke_test_mcu_mbox/caliptra_isr.h
@@ -1,0 +1,310 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ---------------------------------------------------------------------
+// File: caliptra_isr.h
+// Description:
+//     Provides function declarations for use by external test files, so
+//     that the ISR functionality may behave like a library.
+//     TODO:
+//     This header file includes inline function definitions for event and
+//     test specific interrupt service behavior, so it should be copied and
+//     modified for each test.
+// ---------------------------------------------------------------------
+
+#ifndef CALIPTRA_ISR_H
+    #define CALIPTRA_ISR_H
+
+#include "caliptra_defines.h"
+#include <stdint.h>
+#include "printf.h"
+
+/* --------------- symbols/typedefs --------------- */
+typedef struct {
+    uint32_t doe_error;
+    uint32_t doe_notif;
+    uint32_t ecc_error;
+    uint32_t ecc_notif;
+    uint32_t hmac_error;
+    uint32_t hmac_notif;
+    uint32_t kv_error;
+    uint32_t kv_notif;
+    uint32_t sha512_error;
+    uint32_t sha512_notif;
+    uint32_t sha256_error;
+    uint32_t sha256_notif;
+    uint32_t soc_ifc_error;
+    uint32_t soc_ifc_notif;
+    uint32_t sha512_acc_error;
+    uint32_t sha512_acc_notif;
+    uint32_t mldsa_error;
+    uint32_t mldsa_notif;
+    uint32_t axi_dma_error;
+    uint32_t axi_dma_notif;
+} caliptra_intr_received_s;
+extern volatile caliptra_intr_received_s cptra_intr_rcv;
+
+//////////////////////////////////////////////////////////////////////////////
+// Function Declarations
+//
+
+// Performs all the CSR setup to configure and enable vectored external interrupts
+void init_interrupts(void);
+
+// These inline functions are used to insert event-specific functionality into the
+// otherwise generic ISR that gets laid down by the parameterized macro "nonstd_veer_isr"
+inline void service_doe_error_intr() {return;}
+inline void service_doe_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.doe_notif |= DOE_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad doe_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_ecc_error_intr() {return;}
+inline void service_ecc_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.ecc_notif |= ECC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad ecc_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_hmac_error_intr() {return;}
+inline void service_hmac_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.hmac_notif |= HMAC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad hmac_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_kv_error_intr() {return;}
+inline void service_kv_notif_intr() {return;}
+inline void service_sha512_error_intr() {return;}
+inline void service_sha512_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.sha512_notif |= SHA512_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad sha512_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_sha256_error_intr() {return;}
+inline void service_sha256_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.sha256_notif |= SHA256_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad sha256_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+
+inline void service_soc_ifc_error_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INTERNAL_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INTERNAL_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INTERNAL_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INV_DEV_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INV_DEV_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_INV_DEV_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_FAIL_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_FAIL_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_FAIL_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_BAD_FUSE_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_BAD_FUSE_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_BAD_FUSE_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_ICCM_BLOCKED_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_ICCM_BLOCKED_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_ICCM_BLOCKED_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= SOC_IFC_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_ECC_UNC_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad soc_ifc_error_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_soc_ifc_notif_intr () {
+    uint32_t * reg = (uint32_t *) (CLP_SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_AVAIL_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_AVAIL_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_AVAIL_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_MBOX_ECC_COR_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_MBOX_ECC_COR_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_MBOX_ECC_COR_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_DEBUG_LOCKED_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SCAN_MODE_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SOC_REQ_LOCK_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SOC_REQ_LOCK_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_SOC_REQ_LOCK_STS_MASK;
+    }
+    if (sts & SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_GEN_IN_TOGGLE_STS_MASK) {
+        *reg = SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_GEN_IN_TOGGLE_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= SOC_IFC_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_GEN_IN_TOGGLE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad soc_ifc_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_sha512_acc_error_intr() {return;}
+inline void service_sha512_acc_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK) {
+        *reg = SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+        cptra_intr_rcv.sha512_acc_notif |= SHA512_ACC_CSR_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_CMD_DONE_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad sha512_acc_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+inline void service_mldsa_error_intr() {return;}
+inline void service_mldsa_notif_intr() {return;}
+
+inline void service_axi_dma_error_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_AXI_DMA_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & AXI_DMA_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_DEC_STS_MASK) {
+        *reg = AXI_DMA_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_DEC_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= AXI_DMA_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_CMD_DEC_STS_MASK;
+    }
+    if (sts & AXI_DMA_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_AXI_RD_STS_MASK) {
+        *reg = AXI_DMA_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_AXI_RD_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= AXI_DMA_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_AXI_RD_STS_MASK;
+    }
+    if (sts & AXI_DMA_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_AXI_WR_STS_MASK) {
+        *reg = AXI_DMA_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_AXI_WR_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= AXI_DMA_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_AXI_WR_STS_MASK;
+    }
+    if (sts & AXI_DMA_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_LOCK_STS_MASK) {
+        *reg = AXI_DMA_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_LOCK_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= AXI_DMA_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_MBOX_LOCK_STS_MASK;
+    }
+    if (sts & AXI_DMA_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_SHA_LOCK_STS_MASK) {
+        *reg = AXI_DMA_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_SHA_LOCK_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= AXI_DMA_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_SHA_LOCK_STS_MASK;
+    }
+    if (sts & AXI_DMA_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_FIFO_OFLOW_STS_MASK) {
+        *reg = AXI_DMA_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_FIFO_OFLOW_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= AXI_DMA_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_FIFO_OFLOW_STS_MASK;
+    }
+    if (sts & AXI_DMA_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_FIFO_UFLOW_STS_MASK) {
+        *reg = AXI_DMA_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_FIFO_UFLOW_STS_MASK;
+        cptra_intr_rcv.soc_ifc_error |= AXI_DMA_REG_INTR_BLOCK_RF_ERROR_INTERNAL_INTR_R_ERROR_FIFO_UFLOW_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad axi_dma_error_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+inline void service_axi_dma_notif_intr() {
+    uint32_t * reg = (uint32_t *) (CLP_AXI_DMA_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R);
+    uint32_t sts = *reg;
+//    VPRINTF(LOW, "ntf\n");
+    /* Write 1 to Clear the pending interrupt */
+    if (sts & AXI_DMA_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_TXN_DONE_STS_MASK) {
+        *reg = AXI_DMA_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_TXN_DONE_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= AXI_DMA_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_TXN_DONE_STS_MASK;
+    }
+    if (sts & AXI_DMA_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_FIFO_EMPTY_STS_MASK) {
+        *reg = AXI_DMA_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_FIFO_EMPTY_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= AXI_DMA_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_FIFO_EMPTY_STS_MASK;
+    }
+    if (sts & AXI_DMA_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_FIFO_NOT_EMPTY_STS_MASK) {
+        *reg = AXI_DMA_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_FIFO_NOT_EMPTY_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= AXI_DMA_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_FIFO_NOT_EMPTY_STS_MASK;
+    }
+    if (sts & AXI_DMA_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_FIFO_FULL_STS_MASK) {
+        *reg = AXI_DMA_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_FIFO_FULL_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= AXI_DMA_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_FIFO_FULL_STS_MASK;
+    }
+    if (sts & AXI_DMA_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_FIFO_NOT_FULL_STS_MASK) {
+        *reg = AXI_DMA_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_FIFO_NOT_FULL_STS_MASK;
+        cptra_intr_rcv.soc_ifc_notif |= AXI_DMA_REG_INTR_BLOCK_RF_NOTIF_INTERNAL_INTR_R_NOTIF_FIFO_NOT_FULL_STS_MASK;
+    }
+    if (sts == 0) {
+        VPRINTF(ERROR,"bad axi_dma_notif_intr sts:%x\n", sts);
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+}
+
+
+#endif //CALIPTRA_ISR_H

--- a/src/integration/test_suites/smoke_test_mcu_mbox/cptra_ss_mcu_mbox_test.c
+++ b/src/integration/test_suites/smoke_test_mcu_mbox/cptra_ss_mcu_mbox_test.c
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "soc_address_map.h"
+#include "caliptra_defines.h"
+#include "caliptra_isr.h"
+#include "riscv-csr.h"
+#include "veer-csr.h"
+#include "riscv_hw_if.h"
+#include <string.h>
+#include <stdint.h>
+#include "printf.h"
+#include "soc_ifc.h"
+#include "caliptra_reg.h"
+
+volatile char* stdout = (char *)STDOUT;
+volatile uint32_t intr_count       = 0;
+#ifdef CPT_VERBOSITY
+    enum printf_verbosity verbosity_g = CPT_VERBOSITY;
+#else
+    enum printf_verbosity verbosity_g = LOW;
+#endif
+
+volatile caliptra_intr_received_s cptra_intr_rcv = {0};
+
+uint8_t caliptra_ss_mcu_mbox0_acquire_lock(uint32_t attempt_count) {
+    uint32_t read_payload[1];
+    uint32_t mbox_data;
+    uint32_t mbox_lock_accuired;
+    for(uint32_t ii=0; ii<attempt_count; ii++) {
+        soc_ifc_axi_dma_read_ahb_payload(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_LOCK, 0, read_payload, 4, 0);
+        mbox_data = read_payload[0];
+        mbox_lock_accuired = mbox_data & MCU_MBOX0_CSR_MBOX_LOCK_LOCK_MASK;
+        if(mbox_lock_accuired == 0) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+
+uint8_t caliptra_ss_mcu_mbox0_wait_execute(uint32_t attempt_count) {
+    uint32_t read_payload[1];
+    uint32_t mbox_data;
+    uint32_t mbox_lock_accuired;
+    VPRINTF(LOW, "CALIPTRA: MCU MBOX0 WAIT FOR EXECUTE to be SET\n");
+    for(uint32_t ii=0; ii<attempt_count; ii++) {
+        soc_ifc_axi_dma_read_ahb_payload(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_EXECUTE, 0, read_payload, 4, 0);
+        mbox_data = read_payload[0];
+        mbox_data = mbox_data & MCU_MBOX1_CSR_MBOX_EXECUTE_EXECUTE_MASK;
+        if( mbox_data) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+uint32_t caliptra_ss_mcu_mbox0_wait_status_complete(uint32_t attempt_count) {
+    uint32_t read_payload[1];
+    uint32_t mbox_data;
+    uint32_t mbox_lock_accuired;
+    VPRINTF(LOW, "CALIPTRA: MCU MBOX0 WAIT FOR COMPLETE\n");
+    for(uint32_t ii=0; ii<attempt_count; ii++) {
+        soc_ifc_axi_dma_read_ahb_payload(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_CMD_STATUS, 0, read_payload, 4, 0);
+        mbox_data = read_payload[0];
+        mbox_data = mbox_data & MCU_MBOX0_CSR_MBOX_CMD_STATUS_STATUS_MASK;
+        VPRINTF(LOW, "CALIPTRA: MBOX STATUS: 0x%x\n", mbox_data);
+        if (mbox_data == 0x2) {
+            return mbox_data;
+        }
+    }
+    return 1;
+}
+uint8_t caliptra_ss_mcu_mbox0_clear_execution() {
+    uint8_t fail = 0;
+    uint32_t data_length;
+    uint32_t read_payload[16];
+    uint32_t write_payload[16];
+    
+    VPRINTF(LOW, "CALIPTRA: MCU MBOX0 CLEARING EXECUTE\n");
+    write_payload[0] = 0x0;
+    soc_ifc_axi_dma_send_ahb_payload(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_EXECUTE, 0, write_payload, 4, 0) ;
+
+    return fail;
+}
+uint8_t caliptra_ss_mcu_mbox0_send_data_no_wait_status() {
+    uint8_t fail = 0;
+    uint32_t data_length;
+    uint32_t read_payload[16];
+    uint32_t write_payload[16];
+    uint32_t mbox_data[0];
+    VPRINTF(LOW, "CALIPTRA: Requesting MCU MBOX0 LOCK\n");
+    fail = caliptra_ss_mcu_mbox0_acquire_lock(32);
+    if (fail) {
+        VPRINTF(FATAL, "CALIPTRA: MCU MBOX0 Lock Not Acquired\n");
+        SEND_STDOUT_CTRL(0x1);
+        while(1);
+    }
+
+    // Checking MBOX USER INFO
+    if (!fail) {
+        soc_ifc_axi_dma_read_ahb_payload(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_USER, 0, read_payload, 4, 0);
+         
+    }
+    VPRINTF(LOW, "CALIPTRA: MCU MBOX0 USER: 0x%x\n", read_payload[0]);
+
+    VPRINTF(LOW, "CALIPTRA: MCU MBOX0 SETTING COMMAND\n");
+    write_payload[0] = 0xDEADBEEF;
+    soc_ifc_axi_dma_send_ahb_payload(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_CMD, 0, write_payload, 4, 0);
+    
+    VPRINTF(LOW, "CALIPTRA: MCU MBOX0 SETTING DLEN\n");
+    write_payload[0] = 16*4;
+    soc_ifc_axi_dma_send_ahb_payload(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_DLEN, 0, write_payload, 4, 0);
+
+    VPRINTF(LOW, "CALIPTRA: MCU MBOX0 SETTING DATA\n");
+    write_payload[0] = 0x10101010;
+    write_payload[1] = 0x20202020;
+    write_payload[2] = 0x30303030;
+    write_payload[3] = 0x40404040;
+    write_payload[4] = 0x50505050;
+    write_payload[5] = 0x60606060;
+    write_payload[6] = 0x70707070;
+    write_payload[7] = 0x80808080;
+    write_payload[8] = 0x90909090;
+    write_payload[9] = 0xA0A0A0A0;
+    write_payload[10] = 0xB0B0B0B0;
+    write_payload[11] = 0xC0C0C0C0;
+    write_payload[12] = 0xD0D0D0D0;
+    write_payload[13] = 0xE0E0E0E0;
+    write_payload[14] = 0xF0F0F0F0;
+    write_payload[15] = 0x12345678;
+    
+    for (uint32_t ii = 0; ii < 16; ii++) {
+        mbox_data[0] = write_payload[ii];
+        VPRINTF(LOW, "CALIPTRA: Writing to MBOX data: 0x%x\n", write_payload[ii]); 
+        soc_ifc_axi_dma_send_ahb_payload(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_SRAM_BASE_ADDR+(4*ii), 0, mbox_data, 4, 0);
+    }
+
+    VPRINTF(LOW, "CALIPTRA: MCU MBOX0 SETTING EXECUTE\n");
+    write_payload[0] = 0x1;
+    soc_ifc_axi_dma_send_ahb_payload(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_EXECUTE, 0, write_payload, 4, 0);
+    return fail;
+}
+
+uint8_t caliptra_ss_mcu_mbox0_get_data() {
+    uint8_t fail = 0;
+    uint32_t data_length;
+    uint32_t read_payload[16];
+    uint32_t write_payload[16];
+    uint32_t mcu_expected_data[] = { 0x00000000,
+                                    0x11111111,
+                                    0x22222222,
+                                    0x33333333,
+                                    0x44444444,
+                                    0x55555555,
+                                    0x66666666,
+                                    0x77777777,
+                                    0x88888888,
+                                    0x99999999,
+                                    0xaaaaaaaa,
+                                    0xbbbbbbbb,
+                                    0xcccccccc,
+                                    0xdddddddd,
+                                    0xeeeeeeee,
+                                    0xffffffff };
+    
+    fail = caliptra_ss_mcu_mbox0_wait_execute(300);
+    
+    VPRINTF(LOW, "CALIPTRA: Reading MBOX DLEN\n");
+    soc_ifc_axi_dma_read_ahb_payload(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_DLEN, 0, read_payload, 4, 0);
+    data_length = read_payload[0];
+    VPRINTF(LOW, "CALIPTRA: DLEN: 0x%x\n", data_length);
+
+
+    VPRINTF(LOW, "CALIPTRA: Reading MBOX Data\n");
+    for (uint8_t ii = 0; ii < data_length/4; ii++) {
+        soc_ifc_axi_dma_read_ahb_payload(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_SRAM_BASE_ADDR+(4*ii), 0, read_payload, 4, 0);
+        VPRINTF(LOW, "CALIPTRA: MBOX Data[%d]: 0x%x\n", ii, read_payload[0]);
+        if (read_payload[0] != mcu_expected_data[ii]) {
+            VPRINTF(FATAL, "Mbox0 SRAM data from MCU is not expected value - dword: %x\n", ii);
+            SEND_STDOUT_CTRL(0x1);
+            while(1);
+        }
+    }
+
+    VPRINTF(LOW, "CALIPTRA: Sending status complete\n");
+    write_payload[0] = 0x2;
+    soc_ifc_axi_dma_send_ahb_payload(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_CMD_STATUS, 0, write_payload, 4, 0);
+    
+    return fail;
+
+}
+
+
+void main(void) {
+        int argc=0;
+        char *argv[1];
+        uint32_t reg;
+        uint8_t fail = 0;
+        uint32_t read_payload[16];
+        uint32_t data_length;
+        uint32_t write_payload[16];
+
+        VPRINTF(LOW, "----------------------------------\nSmoke Test MCI MBOX0  !!\n----------------------------------\n");
+
+        fail = caliptra_ss_mcu_mbox0_send_data_no_wait_status();
+        if (fail) {
+            VPRINTF(FATAL, "CALIPTRA: FAILED!\n");
+            SEND_STDOUT_CTRL(0x1);
+            while(1);
+        }
+        
+        reg = caliptra_ss_mcu_mbox0_wait_status_complete(200);
+        if (reg == 2) {
+            caliptra_ss_mcu_mbox0_clear_execution();    
+        } else {
+            VPRINTF(FATAL, "CALIPTRA: Timed out waiting for MBOX complete\n");
+            SEND_STDOUT_CTRL(0x1);
+            while(1);
+        }
+
+        fail = caliptra_ss_mcu_mbox0_get_data();
+        if (fail) {
+            VPRINTF(FATAL, "CALIPTRA: FAILED\n");
+            SEND_STDOUT_CTRL(0x1);
+            while(1);
+        }
+
+        VPRINTF(LOW, "CALIPTRA: Sequence complete\n");
+
+}

--- a/src/integration/test_suites/smoke_test_mcu_mbox/smoke_test_mcu_mbox.c
+++ b/src/integration/test_suites/smoke_test_mcu_mbox/smoke_test_mcu_mbox.c
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "soc_address_map.h"
+#include "printf.h"
+#include "riscv_hw_if.h"
+#include "soc_ifc.h"
+#include "caliptra_ss_lib.h"
+#include <string.h>
+#include <stdint.h>
+
+volatile char* stdout = (char *)SOC_MCI_TOP_MCI_REG_DEBUG_OUT;
+
+#ifdef CPT_VERBOSITY
+    enum printf_verbosity verbosity_g = CPT_VERBOSITY;
+#else
+    enum printf_verbosity verbosity_g = LOW;
+#endif
+
+void mcu_mbox0_get_data(){
+    uint32_t clptra_expected_data[] = { 0x10101010,
+                                        0x20202020,
+                                        0x30303030,
+                                        0x40404040,
+                                        0x50505050,
+                                        0x60606060,
+                                        0x70707070,
+                                        0x80808080,
+                                        0x90909090,
+                                        0xA0A0A0A0,
+                                        0xB0B0B0B0,
+                                        0xC0C0C0C0,
+                                        0xD0D0D0D0,
+                                        0xE0E0E0E0,
+                                        0xF0F0F0F0,
+                                        0x12345678 };
+
+    uint32_t mbox_resp_data;
+    uint32_t mbox_dlen;
+
+    VPRINTF(LOW, "MCU: Waiting for caliptra to acquire the lock\n");
+    while(lsu_read_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_USER) == 0);
+    
+    VPRINTF(LOW, "MCU: Waiting for caliptra to set execute\n");
+    while(lsu_read_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_EXECUTE) == 0)
+
+    mbox_dlen = lsu_read_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_DLEN);
+    VPRINTF(LOW, "MCU: Caliptra data length: 0x%x\n", mbox_dlen);
+
+    for (uint32_t ii = 0; ii < mbox_dlen/4; ii++) {
+        mbox_resp_data = lsu_read_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_SRAM_BASE_ADDR+(4*ii));
+        VPRINTF(LOW, "MCU: Reading Caliptra data from MBOX: Data[%d] 0x%x\n", ii, mbox_resp_data);
+        // Compare expected data from Caliptra uC
+        if (mbox_resp_data != clptra_expected_data[ii]) {
+            VPRINTF(FATAL, "MCU: Mbox0 SRAM data from Caliptra is not expected value - dword: %x\n", ii);
+            SEND_STDOUT_CTRL(0x1);
+            while(1);
+        }
+    }
+
+    // MBOX: Write CMD
+    VPRINTF(LOW, "MCU: Writing to MBOX status 0x2\n"); 
+    lsu_write_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_CMD_STATUS, 0x2 );
+
+}
+
+void mcu_mbox0_clear_execute() {
+    uint32_t mbox_resp_data;
+    VPRINTF(LOW, "MCU: Clearing Execute\n");
+    lsu_write_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_EXECUTE, 0x0);
+    
+    mbox_resp_data = lsu_read_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_USER);
+    VPRINTF(LOW, "MCU: MBOX0 USER = %x\n", mbox_resp_data);
+
+}
+
+void mcu_mbox0_send_data_no_wait_status() {
+    uint32_t mbox_resp_data;
+    const uint32_t mbox_dlen = 16*4;
+    uint32_t mbox_data[] = { 0x00000000,
+                             0x11111111,
+                             0x22222222,
+                             0x33333333,
+                             0x44444444,
+                             0x55555555,
+                             0x66666666,
+                             0x77777777,
+                             0x88888888,
+                             0x99999999,
+                             0xaaaaaaaa,
+                             0xbbbbbbbb,
+                             0xcccccccc,
+                             0xdddddddd,
+                             0xeeeeeeee,
+                             0xffffffff };
+    uint32_t mbox_resp_dlen;
+
+    // MBOX: Acquire lock
+    VPRINTF(LOW, "MCU: Waiting for Mbox lock acquired\n");
+    while((lsu_read_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_LOCK) & MCU_MBOX0_CSR_MBOX_LOCK_LOCK_MASK));
+    VPRINTF(LOW, "MCU: Mbox lock acquired\n");
+    
+    mbox_resp_data = lsu_read_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_LOCK);
+    VPRINTF(LOW, "MCU: MBOX0 Lock = %x\n", mbox_resp_data);
+    
+
+    VPRINTF(LOW, "MCU: Checking MBOX USER\n");
+    while(lsu_read_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_USER) == 0);
+    mbox_resp_data = lsu_read_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_USER);
+    VPRINTF(LOW, "MCU: MBOX0 USER = %x\n", mbox_resp_data);
+
+    // MBOX: Write CMD
+    VPRINTF(LOW, "MCU: Writing to MBOX command\n"); 
+    lsu_write_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_CMD, 0xFADECAFE ); // Resp required
+
+    //// MBOX: Write DLEN
+    VPRINTF(LOW, "MCU: Writing to MBOX DLEN\n"); 
+    lsu_write_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_DLEN, mbox_dlen);
+
+    //// MBOX: Write data
+    for (uint32_t ii = 0; ii < mbox_dlen/4; ii++) {
+        VPRINTF(LOW, "MCU: Writing to MBOX data: 0x%x\n", mbox_data[ii]); 
+        lsu_write_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_SRAM_BASE_ADDR+(4*ii), mbox_data[ii]);
+    }
+
+    //// MBOX: Execute
+    VPRINTF(LOW, "MCU: Write Mbox execute\n");
+    lsu_write_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_EXECUTE, MBOX_CSR_MBOX_EXECUTE_EXECUTE_MASK);
+    VPRINTF(LOW, "MCU: Mbox execute\n");
+}
+
+void mcu_mbox0_wait_status_complete() {
+    VPRINTF(LOW, "MCU: Waiting status from Caliptra\n");
+    while((lsu_read_32(SOC_MCI_TOP_MCU_MBOX0_CSR_MBOX_CMD_STATUS) & MBOX_CSR_MBOX_STATUS_STATUS_MASK) != 0x2);
+}
+
+// Test (in conjuction with Caliptra uC C code) does a series of MCU mailbox writes and reads between MCU and Caliptra uC
+// 1. Caliptra uC acquires mailbox, writes data to SRAM, sets EXECUTE
+// 2. MCU waits for execute, reads SRAM and compares to expected value, update MBOX status to complete
+// 3. Caliptra uC will clear execute and wait for MCU.
+// 4. MCU will acquire lock and write data to MCU MBOX and set execute
+// 5. Caliptra will read data from the MCU MBOX SRAM and then set complete status
+// 6. MCU will wait for status complete and then clear execute
+void main (void) {
+    int argc=0;
+    char *argv[1];
+    enum boot_fsm_state_e boot_fsm_ps;
+    const uint32_t mbox_dlen = 16*4;
+    uint32_t mbox_resp_dlen;
+    uint32_t mbox_resp_data;
+    uint32_t mci_boot_fsm_go;
+    uint32_t sram_data;
+    
+    
+    VPRINTF(LOW, "=================\nMCU Configure MCI mailboxes\n=================\n\n")
+    // MBOX: Setup valid AXI
+    lsu_write_32(SOC_MCI_TOP_MCI_REG_MBOX0_VALID_AXI_USER_0, 0x32);
+    lsu_write_32(SOC_MCI_TOP_MCI_REG_MBOX0_VALID_AXI_USER_1, 0x33);
+
+    lsu_write_32(SOC_MCI_TOP_MCI_REG_MBOX0_AXI_USER_LOCK_0, MCI_REG_MBOX0_AXI_USER_LOCK_0_LOCK_MASK);
+    lsu_write_32(SOC_MCI_TOP_MCI_REG_MBOX0_AXI_USER_LOCK_1, MCI_REG_MBOX0_AXI_USER_LOCK_1_LOCK_MASK);
+
+    VPRINTF(LOW, "MCU: Configured MBOX Valid AXI USER\n");
+
+    mcu_mci_boot_go();
+
+    VPRINTF(LOW, "MCU: Caliptra bringup\n")
+
+    mcu_cptra_fuse_init();
+
+    mcu_mbox_clear_lock_out_of_reset();
+
+    ////////////////////////////////////
+    // Mailbox command test
+    ////////////////////////////////////
+
+    // Wait for Caliptra Core to acquire lock, write MBOX data, and set execute
+    // Read MBOX data.  Check that data matches test expectation
+    // Update status
+    mcu_mbox0_get_data();
+
+    // Acquire lock and send data to mailbox
+    // Set execute
+    mcu_mbox0_send_data_no_wait_status();
+
+    // Wait for status complete    
+    mcu_mbox0_wait_status_complete();
+
+    mcu_mbox0_clear_execute();
+
+    VPRINTF(LOW, "MCU: Sequence complete\n");
+
+    SEND_STDOUT_CTRL(0xff);
+}

--- a/src/integration/test_suites/smoke_test_mcu_mbox/smoke_test_mcu_mbox.yml
+++ b/src/integration/test_suites/smoke_test_mcu_mbox/smoke_test_mcu_mbox.yml
@@ -1,0 +1,7 @@
+---
+seed: 1
+testname: smoke_test_mcu_mbox
+pre-exec: |
+  echo "Running pre_exec for [smoke_test_mcu_mbox]"
+  make -f $CALIPTRA_SS_ROOT/tools/scripts/Makefile TESTNAME=smoke_test_mcu_mbox mcu_program.hex
+  CALIPTRA_ROOT=$CALIPTRA_SS_ROOT/third_party/caliptra-rtl make -f $CALIPTRA_SS_ROOT/third_party/caliptra-rtl/tools/scripts/Makefile CALIPTRA_INTERNAL_TRNG=0 TEST_DIR=$CALIPTRA_SS_ROOT/src/integration/test_suites/smoke_test_mcu_mbox TESTNAME=cptra_ss_mcu_mbox_test program.hex

--- a/src/integration/test_suites/smoke_test_mcu_mbox_zeroize/smoke_test_mcu_mbox_zeroize.yml
+++ b/src/integration/test_suites/smoke_test_mcu_mbox_zeroize/smoke_test_mcu_mbox_zeroize.yml
@@ -1,3 +1,7 @@
 ---
 seed: 1
 testname: smoke_test_mcu_mbox_zeroize
+pre-exec: |
+  echo "Running pre_exec for [smoke_test_mcu_mbox_zeroize]"
+  CALIPTRA_ROOT=$CALIPTRA_SS_ROOT/third_party/caliptra-rtl make -f $CALIPTRA_SS_ROOT/third_party/caliptra-rtl/tools/scripts/Makefile CALIPTRA_INTERNAL_TRNG=0 TESTNAME=smoke_test_mbox program.hex
+  make -f $CALIPTRA_SS_ROOT/tools/scripts/Makefile TESTNAME=smoke_test_mcu_mbox_zeroize mcu_program.hex

--- a/src/mci/rtl/mcu_mbox.sv
+++ b/src/mci/rtl/mcu_mbox.sv
@@ -102,7 +102,7 @@ logic mbox_axi_root_user_req ;
 logic lock_set;
 logic valid_requester_target_req;
 
-logic execute_prev;
+logic execute_valid_write;
 logic mbox_sram_zero_done;
 logic mbox_sram_zero_in_progress;
 
@@ -189,14 +189,15 @@ assign hwif_in.valid_root_req             = valid_root_req           ;
 // MBOX Lock and Clearing of Registers
 ///////////////////////////////////////////////
 
+// Detect incoming valid write to execute register.
+// Swmod indication is pulsed one cycle before write data
 always_ff @(posedge clk or negedge rst_b) begin
     if (!rst_b) begin
-        execute_prev <= 1'b0;
+        execute_valid_write <= 1'b0;
     end else begin
-        execute_prev <= hwif_out.mbox_execute.execute.value;
+        execute_valid_write <= (hwif_out.mbox_execute.execute.swmod && valid_requester_req);
     end
 end
-
 
 sram_zeroization_gadget #(
     .SRAM_DEPTH(MCU_MBOX_SRAM_DEPTH),
@@ -234,13 +235,21 @@ always_ff @(posedge clk or negedge rst_b) begin
     end
 end
 
+always_ff @(posedge clk or negedge rst_b) begin
+    if (!rst_b) begin
+        rst_mbox_lock_req <= 1'b1;
+    end else begin
+        rst_mbox_lock_req <= 1'b0;
+    end
+end
+
 always_comb begin
     mbox_sram_zero_end_addr_bytes = mbox_max_dlen - 1;
     mbox_sram_zero_end_addr = {2'b0, mbox_sram_zero_end_addr_bytes[MCU_MBOX_SRAM_ADDR_W-1:2]};
 end
 
-// Release the mailbox one clock cycle after execute is cleared
-assign mbox_release = !hwif_out.mbox_execute.execute.value & execute_prev;  
+// Release the mailbox after execute has had 0 written to it
+assign mbox_release = !hwif_out.mbox_execute.execute.value && execute_valid_write;  
 
 // One reset lock in root_user. Otherwise when lock is not set and user reads
 // the registers set the lock.

--- a/src/mci/rtl/mcu_mbox.sv
+++ b/src/mci/rtl/mcu_mbox.sv
@@ -266,6 +266,7 @@ assign hwif_in.mbox_target_status.status.hwclr = mbox_release;
 assign hwif_in.mbox_target_status.done.hwclr = mbox_release; 
 assign hwif_in.mbox_cmd.command.hwclr = mbox_release; 
 assign hwif_in.mbox_target_user.user.hwclr = mbox_release; 
+assign hwif_in.mbox_user.user.hwclr = mbox_release; 
 
 // User locking is done via RDL. Only need to pass the user value to the HWIF if
 // there is a valid user request.

--- a/src/mci/rtl/mcu_mbox_csr.rdl
+++ b/src/mci/rtl/mcu_mbox_csr.rdl
@@ -57,7 +57,7 @@ addrmap mcu_mbox_csr {
     reg {
         name="Mailbox USER";
         desc="Stores the AXI USER that locked the mailbox. Cleared when lock is cleared.";
-        field {sw=r; hw=rw; we;} user[32]=0;
+        field {sw=r; hw=rw; we; hwclr;} user[32]=0;
     } mbox_user;
     
     mbox_user.user->we  = mbox_lock.lock->hwset;

--- a/src/mci/rtl/mcu_mbox_csr.rdl
+++ b/src/mci/rtl/mcu_mbox_csr.rdl
@@ -91,7 +91,7 @@ addrmap mcu_mbox_csr {
     reg {
         name="Mailbox Execute";
         desc="Mailbox execute register indicates to receiver that the sender is done. ";
-        field {sw=rw; hw=r; swwe=valid_requester_req; } execute=0;
+        field {sw=rw; hw=r; swwe=valid_requester_req; swmod=true;} execute=0;
     } mbox_execute;
 
     reg {   name="Mailbox Target Status";

--- a/src/mci/rtl/mcu_mbox_csr.sv
+++ b/src/mci/rtl/mcu_mbox_csr.sv
@@ -309,6 +309,9 @@ module mcu_mbox_csr (
         if(hwif_in.mbox_lock.lock.hwset) begin // HW Write - we
             next_c = hwif_in.mbox_user.user.next;
             load_next_c = '1;
+        end else if(hwif_in.mbox_user.user.hwclr) begin // HW Clear
+            next_c = '0;
+            load_next_c = '1;
         end
         field_combo.mbox_user.user.next = next_c;
         field_combo.mbox_user.user.load_next = load_next_c;

--- a/src/mci/rtl/mcu_mbox_csr.sv
+++ b/src/mci/rtl/mcu_mbox_csr.sv
@@ -437,6 +437,7 @@ module mcu_mbox_csr (
         end
     end
     assign hwif_out.mbox_execute.execute.value = field_storage.mbox_execute.execute.value;
+    assign hwif_out.mbox_execute.execute.swmod = decoded_reg_strb.mbox_execute && decoded_req_is_wr;
     // Field: mcu_mbox_csr.mbox_target_status.status
     always_comb begin
         automatic logic [3:0] next_c;

--- a/src/mci/rtl/mcu_mbox_csr_pkg.sv
+++ b/src/mci/rtl/mcu_mbox_csr_pkg.sv
@@ -23,6 +23,7 @@ package mcu_mbox_csr_pkg;
 
     typedef struct packed{
         logic [31:0] next;
+        logic hwclr;
     } mcu_mbox_csr__mbox_user_user_70a5ffab__user_we_466f6a8b__in_t;
 
     typedef struct packed{

--- a/src/mci/rtl/mcu_mbox_csr_pkg.sv
+++ b/src/mci/rtl/mcu_mbox_csr_pkg.sv
@@ -164,6 +164,7 @@ package mcu_mbox_csr_pkg;
 
     typedef struct packed{
         logic value;
+        logic swmod;
     } mcu_mbox_csr__mbox_execute__execute__out_t;
 
     typedef struct packed{


### PR DESCRIPTION
-Fix mailbox release detection to be based on valid SW write and data
-Fix mbox_status CSR to get cleared on MBOX lock release
-Add MCU MBOX smoke test with MCU and Caliptra both acquiring and reading/writing MBOX.
-Add MCU MBOX lock return one during zeroize test.
-Add MCU Mbox CSRs are 0 after lock release.
-Update MCU MBOX zeroize smoke test for new infra.
-Add MCU MBOX tests to L0.