### PR TITLE
[RTL]synthesis fix in caliptra_ss_top

### DIFF
--- a/src/integration/rtl/caliptra_ss_top.sv
+++ b/src/integration/rtl/caliptra_ss_top.sv
@@ -873,6 +873,11 @@ module caliptra_ss_top
     //=========================================================================-
     // i3c_core Instance
     //=========================================================================-
+    logic [`AXI_USER_WIDTH-1:0] priv_ids [4];
+    assign priv_ids[0] = 32'd0;
+    assign priv_ids[1] = 32'd0;
+    assign priv_ids[2] = cptra_ss_strap_caliptra_dma_axi_user_i;
+    assign priv_ids[3] = cptra_ss_strap_mcu_lsu_axi_user_i;
 
     i3c_wrapper #(
         .AxiDataWidth(`AXI_DATA_WIDTH),
@@ -935,7 +940,7 @@ module caliptra_ss_top
         .irq_o(i3c_irq_o),
 
         .disable_id_filtering_i(1'b0),
-        .priv_ids_i('{cptra_ss_strap_mcu_lsu_axi_user_i, cptra_ss_strap_caliptra_dma_axi_user_i, 32'b0, 32'b0}) // -- FIXME : ENABLE THIS FEATURE
+        .priv_ids_i(priv_ids) // -- FIXME : ENABLE THIS FEATURE
 
     );
 


### PR DESCRIPTION
RTL fix in caliptra_ss_top, 2D array assignment using concatenation is not allowed.