### PR TITLE
[RTL] Remove clk from VeeR icache export for lint

### DIFF
--- a/src/riscv_core/veer_el2/rtl/design/css_mcu0_el2_mem.sv
+++ b/src/riscv_core/veer_el2/rtl/design/css_mcu0_el2_mem.sv
@@ -96,7 +96,7 @@ import css_mcu0_el2_pkg::*;
 
    css_mcu0_el2_mem_if mem_export_local ();
 
-   //assign mem_export_local.clk = clk;
+   assign mem_export_local.clk = clk;
 
    assign mem_export      .clk                = clk;
 
@@ -117,7 +117,6 @@ import css_mcu0_el2_pkg::*;
    assign mem_export_local.dccm_bank_ecc      = mem_export      .dccm_bank_ecc;
 
    // icache data
-   assign icache_export   .clk                        = clk;
    assign icache_export   .ic_b_sb_wren               = mem_export_local.ic_b_sb_wren;
    assign icache_export   .ic_b_sb_bit_en_vec         = mem_export_local.ic_b_sb_bit_en_vec;
    assign icache_export   .ic_sb_wr_data              = mem_export_local.ic_sb_wr_data;

--- a/src/riscv_core/veer_el2/rtl/design/lib/css_mcu0_el2_mem_if.sv
+++ b/src/riscv_core/veer_el2/rtl/design/lib/css_mcu0_el2_mem_if.sv
@@ -136,7 +136,8 @@ interface css_mcu0_el2_mem_if #(
   );
 
   modport veer_icache_src(
-      output clk,
+      // cache uses the same clk as sram, we do not define clk port in this modport,
+      // assuming the clk will be connected in sram_src
       // data
       output ic_b_sb_wren, ic_b_sb_bit_en_vec, ic_sb_wr_data, ic_rw_addr_bank_q, ic_bank_way_clken_final, ic_bank_way_clken_final_up,
       input wb_packeddout_pre, wb_dout_pre_up,


### PR DESCRIPTION
Per VeeR pull request:
https://github.com/chipsalliance/Cores-VeeR-EL2/pull/403

Resolves a multi-driver issue on the clk signal if the same mem_export interface is used to connect both I-Cache and DCCM/ICCM at the top module that instantiates el2_veer_wrapper