### PR TITLE
[fuse_ctrl, test] Generate mmap header for testsuite

### DIFF
--- a/src/fuse_ctrl/templates/fuse_ctrl_mmap.h.tpl
+++ b/src/fuse_ctrl/templates/fuse_ctrl_mmap.h.tpl
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#ifndef FUSE_CTRL_MMAP_HEADER
+#define FUSE_CTRL_MMAP_HEADER
+
+typedef enum {
+% for i, p in enumerate(partitions):
+    // ${p["name"]}
+% for j, f in enumerate(p["items"]):
+% if f["isdigest"] == False:
+% if i == len(partitions)-1 and j == len(p["items"])-1:
+    ${f["name"]} = ${"0x%04X" % f["offset"]}
+% else:
+    ${f["name"]} = ${"0x%04X" % f["offset"]},
+% endif
+% endif
+% endfor
+% endfor
+} fuse_t;
+
+typedef struct {
+    uint32_t address;
+    uint32_t digest_address;
+    bool is_secret;
+    bool hw_digest;
+    bool sw_digest;
+    bool is_lifecycle;
+    uint32_t num_fuses;
+    uint32_t *fuses;
+} partition_t;
+
+#define NUM_PARTITIONS ${len(partitions)}
+
+% for i, p in enumerate(partitions[:len(partitions)]):
+uint32_t ${p["name"].lower()}_fuses[] = {
+% if p["hw_digest"] or p["sw_digest"]:
+% for j, f in enumerate(p["items"][:len(p["items"])-1]):
+% if j < len(p["items"])-2:
+    ${f["name"]},
+% else:
+    ${f["name"]}
+% endif
+% endfor
+% else:
+% for j, f in enumerate(p["items"][:len(p["items"])]):
+% if j < len(p["items"])-1:
+    ${f["name"]},
+% else:
+    ${f["name"]}
+% endif
+% endfor
+% endif
+};
+% endfor
+
+partition_t partitions[NUM_PARTITIONS] = {
+% for i, p in enumerate(partitions[:len(partitions)-1]):
+    // ${p["name"]}
+    {
+        .address = ${"0x%04X" % p["offset"]},
+% if p["sw_digest"] or p["hw_digest"]:
+        .digest_address = ${"0x%04X" % p["items"][len(p["items"])-1]["offset"]},
+% else:
+        .digest_address = 0x0000,
+% endif
+% if p["secret"]:
+        .is_secret = true,
+% else:
+        .is_secret = false,
+% endif
+% if p["hw_digest"]:
+        .hw_digest = true,
+% else:
+        .hw_digest = false,
+% endif
+% if p["sw_digest"]:
+        .sw_digest = true,
+% else:
+        .sw_digest = false,
+% endif
+        .is_lifecycle = false,
+        .num_fuses = ${len(p["items"])-1},
+        .fuses = ${p["name"].lower() + "_fuses"}
+    },
+% endfor
+    // LIFE_CYCLE
+    {
+        .address = ${"0x%04X" % partitions[len(partitions)-1]["offset"]},
+        .digest_address = 0x0000,
+        .is_secret = false,
+        .hw_digest = false,
+        .sw_digest = false,
+        .is_lifecycle = true,
+        .num_fuses = 2,
+        .fuses = life_cycle_fuses
+    }
+};
+
+#endif // FUSE_CTRL_MMAP_HEADER

--- a/src/integration/rtl/fuse_ctrl_mmap.h
+++ b/src/integration/rtl/fuse_ctrl_mmap.h
@@ -1,0 +1,561 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#ifndef FUSE_CTRL_MMAP_HEADER
+#define FUSE_CTRL_MMAP_HEADER
+
+typedef enum {
+    // SW_TEST_UNLOCK_PARTITION
+    CPTRA_CORE_MANUF_DEBUG_UNLOCK_TOKEN = 0x0000,
+    // SECRET_MANUF_PARTITION
+    CPTRA_CORE_UDS_SEED = 0x0048,
+    // SECRET_PROD_PARTITION_0
+    CPTRA_CORE_FIELD_ENTROPY_0 = 0x0090,
+    // SECRET_PROD_PARTITION_1
+    CPTRA_CORE_FIELD_ENTROPY_1 = 0x00A0,
+    // SECRET_PROD_PARTITION_2
+    CPTRA_CORE_FIELD_ENTROPY_2 = 0x00B0,
+    // SECRET_PROD_PARTITION_3
+    CPTRA_CORE_FIELD_ENTROPY_3 = 0x00C0,
+    // SW_MANUF_PARTITION
+    CPTRA_CORE_ANTI_ROLLBACK_DISABLE = 0x00D0,
+    CPTRA_CORE_IDEVID_CERT_IDEVID_ATTR = 0x00D1,
+    CPTRA_CORE_IDEVID_MANUF_HSM_IDENTIFIER = 0x1FE1,
+    CPTRA_CORE_SOC_STEPPING_ID = 0x1FF1,
+    CPTRA_SS_PROD_DEBUG_UNLOCK_PKS_0 = 0x1FF3,
+    CPTRA_SS_PROD_DEBUG_UNLOCK_PKS_1 = 0x2023,
+    CPTRA_SS_PROD_DEBUG_UNLOCK_PKS_2 = 0x2053,
+    CPTRA_SS_PROD_DEBUG_UNLOCK_PKS_3 = 0x2083,
+    CPTRA_SS_PROD_DEBUG_UNLOCK_PKS_4 = 0x20B3,
+    CPTRA_SS_PROD_DEBUG_UNLOCK_PKS_5 = 0x20E3,
+    CPTRA_SS_PROD_DEBUG_UNLOCK_PKS_6 = 0x2113,
+    CPTRA_SS_PROD_DEBUG_UNLOCK_PKS_7 = 0x2143,
+    // SECRET_LC_TRANSITION_PARTITION
+    CPTRA_SS_TEST_UNLOCK_TOKEN_1 = 0x2C18,
+    CPTRA_SS_TEST_UNLOCK_TOKEN_2 = 0x2C28,
+    CPTRA_SS_TEST_UNLOCK_TOKEN_3 = 0x2C38,
+    CPTRA_SS_TEST_UNLOCK_TOKEN_4 = 0x2C48,
+    CPTRA_SS_TEST_UNLOCK_TOKEN_5 = 0x2C58,
+    CPTRA_SS_TEST_UNLOCK_TOKEN_6 = 0x2C68,
+    CPTRA_SS_TEST_UNLOCK_TOKEN_7 = 0x2C78,
+    CPTRA_SS_TEST_EXIT_TO_MANUF_TOKEN = 0x2C88,
+    CPTRA_SS_MANUF_TO_PROD_TOKEN = 0x2C98,
+    CPTRA_SS_PROD_TO_PROD_END_TOKEN = 0x2CA8,
+    CPTRA_SS_RMA_TOKEN = 0x2CB8,
+    // SVN_PARTITION
+    CPTRA_CORE_FMC_KEY_MANIFEST_SVN = 0x2CD0,
+    CPTRA_CORE_RUNTIME_SVN = 0x2CD4,
+    CPTRA_CORE_SOC_MANIFEST_SVN = 0x2CE4,
+    CPTRA_CORE_SOC_MANIFEST_MAX_SVN = 0x2CF4,
+    // VENDOR_TEST_PARTITION
+    VENDOR_TEST = 0x2CF8,
+    // VENDOR_HASHES_MANUF_PARTITION
+    CPTRA_CORE_VENDOR_PK_HASH_0 = 0x2D38,
+    CPTRA_CORE_PQC_KEY_TYPE_0 = 0x2D68,
+    // VENDOR_HASHES_PROD_PARTITION
+    CPTRA_CORE_VENDOR_PK_HASH_1 = 0x2D78,
+    CPTRA_CORE_PQC_KEY_TYPE_1 = 0x2DA8,
+    CPTRA_CORE_VENDOR_PK_HASH_2 = 0x2DA9,
+    CPTRA_CORE_PQC_KEY_TYPE_2 = 0x2DD9,
+    CPTRA_CORE_VENDOR_PK_HASH_3 = 0x2DDA,
+    CPTRA_CORE_PQC_KEY_TYPE_3 = 0x2E0A,
+    CPTRA_CORE_VENDOR_PK_HASH_4 = 0x2E0B,
+    CPTRA_CORE_PQC_KEY_TYPE_4 = 0x2E3B,
+    CPTRA_CORE_VENDOR_PK_HASH_5 = 0x2E3C,
+    CPTRA_CORE_PQC_KEY_TYPE_5 = 0x2E6C,
+    CPTRA_CORE_VENDOR_PK_HASH_6 = 0x2E6D,
+    CPTRA_CORE_PQC_KEY_TYPE_6 = 0x2E9D,
+    CPTRA_CORE_VENDOR_PK_HASH_7 = 0x2E9E,
+    CPTRA_CORE_PQC_KEY_TYPE_7 = 0x2ECE,
+    CPTRA_CORE_VENDOR_PK_HASH_8 = 0x2ECF,
+    CPTRA_CORE_PQC_KEY_TYPE_8 = 0x2EFF,
+    CPTRA_CORE_VENDOR_PK_HASH_9 = 0x2F00,
+    CPTRA_CORE_PQC_KEY_TYPE_9 = 0x2F30,
+    CPTRA_CORE_VENDOR_PK_HASH_10 = 0x2F31,
+    CPTRA_CORE_PQC_KEY_TYPE_10 = 0x2F61,
+    CPTRA_CORE_VENDOR_PK_HASH_11 = 0x2F62,
+    CPTRA_CORE_PQC_KEY_TYPE_11 = 0x2F92,
+    CPTRA_CORE_VENDOR_PK_HASH_12 = 0x2F93,
+    CPTRA_CORE_PQC_KEY_TYPE_12 = 0x2FC3,
+    CPTRA_CORE_VENDOR_PK_HASH_13 = 0x2FC4,
+    CPTRA_CORE_PQC_KEY_TYPE_13 = 0x2FF4,
+    CPTRA_CORE_VENDOR_PK_HASH_14 = 0x2FF5,
+    CPTRA_CORE_PQC_KEY_TYPE_14 = 0x3025,
+    CPTRA_CORE_VENDOR_PK_HASH_15 = 0x3026,
+    CPTRA_CORE_PQC_KEY_TYPE_15 = 0x3056,
+    CPTRA_CORE_VENDOR_PK_HASH_VALID = 0x3057,
+    // VENDOR_REVOCATIONS_PROD_PARTITION
+    CPTRA_CORE_ECC_REVOCATION_0 = 0x3068,
+    CPTRA_CORE_LMS_REVOCATION_0 = 0x3069,
+    CPTRA_CORE_MLDSA_REVOCATION_0 = 0x306D,
+    CPTRA_CORE_ECC_REVOCATION_1 = 0x3071,
+    CPTRA_CORE_LMS_REVOCATION_1 = 0x3072,
+    CPTRA_CORE_MLDSA_REVOCATION_1 = 0x3076,
+    CPTRA_CORE_ECC_REVOCATION_2 = 0x307A,
+    CPTRA_CORE_LMS_REVOCATION_2 = 0x307B,
+    CPTRA_CORE_MLDSA_REVOCATION_2 = 0x307F,
+    CPTRA_CORE_ECC_REVOCATION_3 = 0x3083,
+    CPTRA_CORE_LMS_REVOCATION_3 = 0x3084,
+    CPTRA_CORE_MLDSA_REVOCATION_3 = 0x3088,
+    CPTRA_CORE_ECC_REVOCATION_4 = 0x308C,
+    CPTRA_CORE_LMS_REVOCATION_4 = 0x308D,
+    CPTRA_CORE_MLDSA_REVOCATION_4 = 0x3091,
+    CPTRA_CORE_ECC_REVOCATION_5 = 0x3095,
+    CPTRA_CORE_LMS_REVOCATION_5 = 0x3096,
+    CPTRA_CORE_MLDSA_REVOCATION_5 = 0x309A,
+    CPTRA_CORE_ECC_REVOCATION_6 = 0x309E,
+    CPTRA_CORE_LMS_REVOCATION_6 = 0x309F,
+    CPTRA_CORE_MLDSA_REVOCATION_6 = 0x30A3,
+    CPTRA_CORE_ECC_REVOCATION_7 = 0x30A7,
+    CPTRA_CORE_LMS_REVOCATION_7 = 0x30A8,
+    CPTRA_CORE_MLDSA_REVOCATION_7 = 0x30AC,
+    CPTRA_CORE_ECC_REVOCATION_8 = 0x30B0,
+    CPTRA_CORE_LMS_REVOCATION_8 = 0x30B1,
+    CPTRA_CORE_MLDSA_REVOCATION_8 = 0x30B5,
+    CPTRA_CORE_ECC_REVOCATION_9 = 0x30B9,
+    CPTRA_CORE_LMS_REVOCATION_9 = 0x30BA,
+    CPTRA_CORE_MLDSA_REVOCATION_9 = 0x30BE,
+    CPTRA_CORE_ECC_REVOCATION_10 = 0x30C2,
+    CPTRA_CORE_LMS_REVOCATION_10 = 0x30C3,
+    CPTRA_CORE_MLDSA_REVOCATION_10 = 0x30C7,
+    CPTRA_CORE_ECC_REVOCATION_11 = 0x30CB,
+    CPTRA_CORE_LMS_REVOCATION_11 = 0x30CC,
+    CPTRA_CORE_MLDSA_REVOCATION_11 = 0x30D0,
+    CPTRA_CORE_ECC_REVOCATION_12 = 0x30D4,
+    CPTRA_CORE_LMS_REVOCATION_12 = 0x30D5,
+    CPTRA_CORE_MLDSA_REVOCATION_12 = 0x30D9,
+    CPTRA_CORE_ECC_REVOCATION_13 = 0x30DD,
+    CPTRA_CORE_LMS_REVOCATION_13 = 0x30DE,
+    CPTRA_CORE_MLDSA_REVOCATION_13 = 0x30E2,
+    CPTRA_CORE_ECC_REVOCATION_14 = 0x30E6,
+    CPTRA_CORE_LMS_REVOCATION_14 = 0x30E7,
+    CPTRA_CORE_MLDSA_REVOCATION_14 = 0x30EB,
+    CPTRA_CORE_ECC_REVOCATION_15 = 0x30EF,
+    CPTRA_CORE_LMS_REVOCATION_15 = 0x30F0,
+    CPTRA_CORE_MLDSA_REVOCATION_15 = 0x30F4,
+    // VENDOR_SECRET_PROD_PARTITION
+    CPTRA_SS_VENDOR_SPECIFIC_SECRET_FUSE_0 = 0x3100,
+    CPTRA_SS_VENDOR_SPECIFIC_SECRET_FUSE_1 = 0x3120,
+    CPTRA_SS_VENDOR_SPECIFIC_SECRET_FUSE_2 = 0x3140,
+    CPTRA_SS_VENDOR_SPECIFIC_SECRET_FUSE_3 = 0x3160,
+    CPTRA_SS_VENDOR_SPECIFIC_SECRET_FUSE_4 = 0x3180,
+    CPTRA_SS_VENDOR_SPECIFIC_SECRET_FUSE_5 = 0x31A0,
+    CPTRA_SS_VENDOR_SPECIFIC_SECRET_FUSE_6 = 0x31C0,
+    CPTRA_SS_VENDOR_SPECIFIC_SECRET_FUSE_7 = 0x31E0,
+    CPTRA_SS_VENDOR_SPECIFIC_SECRET_FUSE_8 = 0x3200,
+    CPTRA_SS_VENDOR_SPECIFIC_SECRET_FUSE_9 = 0x3220,
+    CPTRA_SS_VENDOR_SPECIFIC_SECRET_FUSE_10 = 0x3240,
+    CPTRA_SS_VENDOR_SPECIFIC_SECRET_FUSE_11 = 0x3260,
+    CPTRA_SS_VENDOR_SPECIFIC_SECRET_FUSE_12 = 0x3280,
+    CPTRA_SS_VENDOR_SPECIFIC_SECRET_FUSE_13 = 0x32A0,
+    CPTRA_SS_VENDOR_SPECIFIC_SECRET_FUSE_14 = 0x32C0,
+    CPTRA_SS_VENDOR_SPECIFIC_SECRET_FUSE_15 = 0x32E0,
+    // VENDOR_NON_SECRET_PROD_PARTITION
+    CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_0 = 0x3308,
+    CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_1 = 0x3328,
+    CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_2 = 0x3348,
+    CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_3 = 0x3368,
+    CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_4 = 0x3388,
+    CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_5 = 0x33A8,
+    CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_6 = 0x33C8,
+    CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_7 = 0x33E8,
+    CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_8 = 0x3408,
+    CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_9 = 0x3428,
+    CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_10 = 0x3448,
+    CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_11 = 0x3468,
+    CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_12 = 0x3488,
+    CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_13 = 0x34A8,
+    CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_14 = 0x34C8,
+    CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_15 = 0x34E8,
+    // LIFE_CYCLE
+    LC_TRANSITION_CNT = 0x3FA8,
+    LC_STATE = 0x3FD8
+} fuse_t;
+
+typedef struct {
+    uint32_t address;
+    uint32_t digest_address;
+    bool is_secret;
+    bool hw_digest;
+    bool sw_digest;
+    bool is_lifecycle;
+    uint32_t num_fuses;
+    uint32_t *fuses;
+} partition_t;
+
+#define NUM_PARTITIONS 16
+
+uint32_t sw_test_unlock_partition_fuses[] = {
+    CPTRA_CORE_MANUF_DEBUG_UNLOCK_TOKEN
+};
+uint32_t secret_manuf_partition_fuses[] = {
+    CPTRA_CORE_UDS_SEED
+};
+uint32_t secret_prod_partition_0_fuses[] = {
+    CPTRA_CORE_FIELD_ENTROPY_0
+};
+uint32_t secret_prod_partition_1_fuses[] = {
+    CPTRA_CORE_FIELD_ENTROPY_1
+};
+uint32_t secret_prod_partition_2_fuses[] = {
+    CPTRA_CORE_FIELD_ENTROPY_2
+};
+uint32_t secret_prod_partition_3_fuses[] = {
+    CPTRA_CORE_FIELD_ENTROPY_3
+};
+uint32_t sw_manuf_partition_fuses[] = {
+    CPTRA_CORE_ANTI_ROLLBACK_DISABLE,
+    CPTRA_CORE_IDEVID_CERT_IDEVID_ATTR,
+    CPTRA_CORE_IDEVID_MANUF_HSM_IDENTIFIER,
+    CPTRA_CORE_SOC_STEPPING_ID,
+    CPTRA_SS_PROD_DEBUG_UNLOCK_PKS_0,
+    CPTRA_SS_PROD_DEBUG_UNLOCK_PKS_1,
+    CPTRA_SS_PROD_DEBUG_UNLOCK_PKS_2,
+    CPTRA_SS_PROD_DEBUG_UNLOCK_PKS_3,
+    CPTRA_SS_PROD_DEBUG_UNLOCK_PKS_4,
+    CPTRA_SS_PROD_DEBUG_UNLOCK_PKS_5,
+    CPTRA_SS_PROD_DEBUG_UNLOCK_PKS_6,
+    CPTRA_SS_PROD_DEBUG_UNLOCK_PKS_7
+};
+uint32_t secret_lc_transition_partition_fuses[] = {
+    CPTRA_SS_TEST_UNLOCK_TOKEN_1,
+    CPTRA_SS_TEST_UNLOCK_TOKEN_2,
+    CPTRA_SS_TEST_UNLOCK_TOKEN_3,
+    CPTRA_SS_TEST_UNLOCK_TOKEN_4,
+    CPTRA_SS_TEST_UNLOCK_TOKEN_5,
+    CPTRA_SS_TEST_UNLOCK_TOKEN_6,
+    CPTRA_SS_TEST_UNLOCK_TOKEN_7,
+    CPTRA_SS_TEST_EXIT_TO_MANUF_TOKEN,
+    CPTRA_SS_MANUF_TO_PROD_TOKEN,
+    CPTRA_SS_PROD_TO_PROD_END_TOKEN,
+    CPTRA_SS_RMA_TOKEN
+};
+uint32_t svn_partition_fuses[] = {
+    CPTRA_CORE_FMC_KEY_MANIFEST_SVN,
+    CPTRA_CORE_RUNTIME_SVN,
+    CPTRA_CORE_SOC_MANIFEST_SVN,
+    CPTRA_CORE_SOC_MANIFEST_MAX_SVN
+};
+uint32_t vendor_test_partition_fuses[] = {
+    VENDOR_TEST
+};
+uint32_t vendor_hashes_manuf_partition_fuses[] = {
+    CPTRA_CORE_VENDOR_PK_HASH_0,
+    CPTRA_CORE_PQC_KEY_TYPE_0
+};
+uint32_t vendor_hashes_prod_partition_fuses[] = {
+    CPTRA_CORE_VENDOR_PK_HASH_1,
+    CPTRA_CORE_PQC_KEY_TYPE_1,
+    CPTRA_CORE_VENDOR_PK_HASH_2,
+    CPTRA_CORE_PQC_KEY_TYPE_2,
+    CPTRA_CORE_VENDOR_PK_HASH_3,
+    CPTRA_CORE_PQC_KEY_TYPE_3,
+    CPTRA_CORE_VENDOR_PK_HASH_4,
+    CPTRA_CORE_PQC_KEY_TYPE_4,
+    CPTRA_CORE_VENDOR_PK_HASH_5,
+    CPTRA_CORE_PQC_KEY_TYPE_5,
+    CPTRA_CORE_VENDOR_PK_HASH_6,
+    CPTRA_CORE_PQC_KEY_TYPE_6,
+    CPTRA_CORE_VENDOR_PK_HASH_7,
+    CPTRA_CORE_PQC_KEY_TYPE_7,
+    CPTRA_CORE_VENDOR_PK_HASH_8,
+    CPTRA_CORE_PQC_KEY_TYPE_8,
+    CPTRA_CORE_VENDOR_PK_HASH_9,
+    CPTRA_CORE_PQC_KEY_TYPE_9,
+    CPTRA_CORE_VENDOR_PK_HASH_10,
+    CPTRA_CORE_PQC_KEY_TYPE_10,
+    CPTRA_CORE_VENDOR_PK_HASH_11,
+    CPTRA_CORE_PQC_KEY_TYPE_11,
+    CPTRA_CORE_VENDOR_PK_HASH_12,
+    CPTRA_CORE_PQC_KEY_TYPE_12,
+    CPTRA_CORE_VENDOR_PK_HASH_13,
+    CPTRA_CORE_PQC_KEY_TYPE_13,
+    CPTRA_CORE_VENDOR_PK_HASH_14,
+    CPTRA_CORE_PQC_KEY_TYPE_14,
+    CPTRA_CORE_VENDOR_PK_HASH_15,
+    CPTRA_CORE_PQC_KEY_TYPE_15,
+    CPTRA_CORE_VENDOR_PK_HASH_VALID
+};
+uint32_t vendor_revocations_prod_partition_fuses[] = {
+    CPTRA_CORE_ECC_REVOCATION_0,
+    CPTRA_CORE_LMS_REVOCATION_0,
+    CPTRA_CORE_MLDSA_REVOCATION_0,
+    CPTRA_CORE_ECC_REVOCATION_1,
+    CPTRA_CORE_LMS_REVOCATION_1,
+    CPTRA_CORE_MLDSA_REVOCATION_1,
+    CPTRA_CORE_ECC_REVOCATION_2,
+    CPTRA_CORE_LMS_REVOCATION_2,
+    CPTRA_CORE_MLDSA_REVOCATION_2,
+    CPTRA_CORE_ECC_REVOCATION_3,
+    CPTRA_CORE_LMS_REVOCATION_3,
+    CPTRA_CORE_MLDSA_REVOCATION_3,
+    CPTRA_CORE_ECC_REVOCATION_4,
+    CPTRA_CORE_LMS_REVOCATION_4,
+    CPTRA_CORE_MLDSA_REVOCATION_4,
+    CPTRA_CORE_ECC_REVOCATION_5,
+    CPTRA_CORE_LMS_REVOCATION_5,
+    CPTRA_CORE_MLDSA_REVOCATION_5,
+    CPTRA_CORE_ECC_REVOCATION_6,
+    CPTRA_CORE_LMS_REVOCATION_6,
+    CPTRA_CORE_MLDSA_REVOCATION_6,
+    CPTRA_CORE_ECC_REVOCATION_7,
+    CPTRA_CORE_LMS_REVOCATION_7,
+    CPTRA_CORE_MLDSA_REVOCATION_7,
+    CPTRA_CORE_ECC_REVOCATION_8,
+    CPTRA_CORE_LMS_REVOCATION_8,
+    CPTRA_CORE_MLDSA_REVOCATION_8,
+    CPTRA_CORE_ECC_REVOCATION_9,
+    CPTRA_CORE_LMS_REVOCATION_9,
+    CPTRA_CORE_MLDSA_REVOCATION_9,
+    CPTRA_CORE_ECC_REVOCATION_10,
+    CPTRA_CORE_LMS_REVOCATION_10,
+    CPTRA_CORE_MLDSA_REVOCATION_10,
+    CPTRA_CORE_ECC_REVOCATION_11,
+    CPTRA_CORE_LMS_REVOCATION_11,
+    CPTRA_CORE_MLDSA_REVOCATION_11,
+    CPTRA_CORE_ECC_REVOCATION_12,
+    CPTRA_CORE_LMS_REVOCATION_12,
+    CPTRA_CORE_MLDSA_REVOCATION_12,
+    CPTRA_CORE_ECC_REVOCATION_13,
+    CPTRA_CORE_LMS_REVOCATION_13,
+    CPTRA_CORE_MLDSA_REVOCATION_13,
+    CPTRA_CORE_ECC_REVOCATION_14,
+    CPTRA_CORE_LMS_REVOCATION_14,
+    CPTRA_CORE_MLDSA_REVOCATION_14,
+    CPTRA_CORE_ECC_REVOCATION_15,
+    CPTRA_CORE_LMS_REVOCATION_15,
+    CPTRA_CORE_MLDSA_REVOCATION_15
+};
+uint32_t vendor_secret_prod_partition_fuses[] = {
+    CPTRA_SS_VENDOR_SPECIFIC_SECRET_FUSE_0,
+    CPTRA_SS_VENDOR_SPECIFIC_SECRET_FUSE_1,
+    CPTRA_SS_VENDOR_SPECIFIC_SECRET_FUSE_2,
+    CPTRA_SS_VENDOR_SPECIFIC_SECRET_FUSE_3,
+    CPTRA_SS_VENDOR_SPECIFIC_SECRET_FUSE_4,
+    CPTRA_SS_VENDOR_SPECIFIC_SECRET_FUSE_5,
+    CPTRA_SS_VENDOR_SPECIFIC_SECRET_FUSE_6,
+    CPTRA_SS_VENDOR_SPECIFIC_SECRET_FUSE_7,
+    CPTRA_SS_VENDOR_SPECIFIC_SECRET_FUSE_8,
+    CPTRA_SS_VENDOR_SPECIFIC_SECRET_FUSE_9,
+    CPTRA_SS_VENDOR_SPECIFIC_SECRET_FUSE_10,
+    CPTRA_SS_VENDOR_SPECIFIC_SECRET_FUSE_11,
+    CPTRA_SS_VENDOR_SPECIFIC_SECRET_FUSE_12,
+    CPTRA_SS_VENDOR_SPECIFIC_SECRET_FUSE_13,
+    CPTRA_SS_VENDOR_SPECIFIC_SECRET_FUSE_14,
+    CPTRA_SS_VENDOR_SPECIFIC_SECRET_FUSE_15
+};
+uint32_t vendor_non_secret_prod_partition_fuses[] = {
+    CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_0,
+    CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_1,
+    CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_2,
+    CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_3,
+    CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_4,
+    CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_5,
+    CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_6,
+    CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_7,
+    CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_8,
+    CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_9,
+    CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_10,
+    CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_11,
+    CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_12,
+    CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_13,
+    CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_14,
+    CPTRA_SS_VENDOR_SPECIFIC_NON_SECRET_FUSE_15
+};
+uint32_t life_cycle_fuses[] = {
+    LC_TRANSITION_CNT,
+    LC_STATE
+};
+
+partition_t partitions[NUM_PARTITIONS] = {
+    // SW_TEST_UNLOCK_PARTITION
+    {
+        .address = 0x0000,
+        .digest_address = 0x0040,
+        .is_secret = false,
+        .hw_digest = true,
+        .sw_digest = false,
+        .is_lifecycle = false,
+        .num_fuses = 1,
+        .fuses = sw_test_unlock_partition_fuses
+    },
+    // SECRET_MANUF_PARTITION
+    {
+        .address = 0x0048,
+        .digest_address = 0x0088,
+        .is_secret = true,
+        .hw_digest = true,
+        .sw_digest = false,
+        .is_lifecycle = false,
+        .num_fuses = 1,
+        .fuses = secret_manuf_partition_fuses
+    },
+    // SECRET_PROD_PARTITION_0
+    {
+        .address = 0x0090,
+        .digest_address = 0x0098,
+        .is_secret = true,
+        .hw_digest = true,
+        .sw_digest = false,
+        .is_lifecycle = false,
+        .num_fuses = 1,
+        .fuses = secret_prod_partition_0_fuses
+    },
+    // SECRET_PROD_PARTITION_1
+    {
+        .address = 0x00A0,
+        .digest_address = 0x00A8,
+        .is_secret = true,
+        .hw_digest = true,
+        .sw_digest = false,
+        .is_lifecycle = false,
+        .num_fuses = 1,
+        .fuses = secret_prod_partition_1_fuses
+    },
+    // SECRET_PROD_PARTITION_2
+    {
+        .address = 0x00B0,
+        .digest_address = 0x00B8,
+        .is_secret = true,
+        .hw_digest = true,
+        .sw_digest = false,
+        .is_lifecycle = false,
+        .num_fuses = 1,
+        .fuses = secret_prod_partition_2_fuses
+    },
+    // SECRET_PROD_PARTITION_3
+    {
+        .address = 0x00C0,
+        .digest_address = 0x00C8,
+        .is_secret = true,
+        .hw_digest = true,
+        .sw_digest = false,
+        .is_lifecycle = false,
+        .num_fuses = 1,
+        .fuses = secret_prod_partition_3_fuses
+    },
+    // SW_MANUF_PARTITION
+    {
+        .address = 0x00D0,
+        .digest_address = 0x2C10,
+        .is_secret = false,
+        .hw_digest = false,
+        .sw_digest = true,
+        .is_lifecycle = false,
+        .num_fuses = 12,
+        .fuses = sw_manuf_partition_fuses
+    },
+    // SECRET_LC_TRANSITION_PARTITION
+    {
+        .address = 0x2C18,
+        .digest_address = 0x2CC8,
+        .is_secret = true,
+        .hw_digest = true,
+        .sw_digest = false,
+        .is_lifecycle = false,
+        .num_fuses = 11,
+        .fuses = secret_lc_transition_partition_fuses
+    },
+    // SVN_PARTITION
+    {
+        .address = 0x2CD0,
+        .digest_address = 0x0000,
+        .is_secret = false,
+        .hw_digest = false,
+        .sw_digest = false,
+        .is_lifecycle = false,
+        .num_fuses = 3,
+        .fuses = svn_partition_fuses
+    },
+    // VENDOR_TEST_PARTITION
+    {
+        .address = 0x2CF8,
+        .digest_address = 0x2D30,
+        .is_secret = false,
+        .hw_digest = false,
+        .sw_digest = true,
+        .is_lifecycle = false,
+        .num_fuses = 1,
+        .fuses = vendor_test_partition_fuses
+    },
+    // VENDOR_HASHES_MANUF_PARTITION
+    {
+        .address = 0x2D38,
+        .digest_address = 0x2D70,
+        .is_secret = false,
+        .hw_digest = false,
+        .sw_digest = true,
+        .is_lifecycle = false,
+        .num_fuses = 2,
+        .fuses = vendor_hashes_manuf_partition_fuses
+    },
+    // VENDOR_HASHES_PROD_PARTITION
+    {
+        .address = 0x2D78,
+        .digest_address = 0x3060,
+        .is_secret = false,
+        .hw_digest = false,
+        .sw_digest = true,
+        .is_lifecycle = false,
+        .num_fuses = 31,
+        .fuses = vendor_hashes_prod_partition_fuses
+    },
+    // VENDOR_REVOCATIONS_PROD_PARTITION
+    {
+        .address = 0x3068,
+        .digest_address = 0x30F8,
+        .is_secret = false,
+        .hw_digest = false,
+        .sw_digest = true,
+        .is_lifecycle = false,
+        .num_fuses = 48,
+        .fuses = vendor_revocations_prod_partition_fuses
+    },
+    // VENDOR_SECRET_PROD_PARTITION
+    {
+        .address = 0x3100,
+        .digest_address = 0x3300,
+        .is_secret = true,
+        .hw_digest = true,
+        .sw_digest = false,
+        .is_lifecycle = false,
+        .num_fuses = 16,
+        .fuses = vendor_secret_prod_partition_fuses
+    },
+    // VENDOR_NON_SECRET_PROD_PARTITION
+    {
+        .address = 0x3308,
+        .digest_address = 0x3FA0,
+        .is_secret = false,
+        .hw_digest = false,
+        .sw_digest = true,
+        .is_lifecycle = false,
+        .num_fuses = 16,
+        .fuses = vendor_non_secret_prod_partition_fuses
+    },
+    // LIFE_CYCLE
+    {
+        .address = 0x3FA8,
+        .digest_address = 0x0000,
+        .is_secret = false,
+        .hw_digest = false,
+        .sw_digest = false,
+        .is_lifecycle = true,
+        .num_fuses = 2,
+        .fuses = life_cycle_fuses
+    }
+};
+
+#endif // FUSE_CTRL_MMAP_HEADER

--- a/src/integration/rtl/fuse_ctrl_mmap.h
+++ b/src/integration/rtl/fuse_ctrl_mmap.h
@@ -14,7 +14,7 @@
 //
 
 #ifndef FUSE_CTRL_MMAP_HEADER
-#define FUSE_CTRL_MMAP_HEADER
+#define FUSE_CTRL_MMAP_HEADERS
 
 typedef enum {
     // SW_TEST_UNLOCK_PARTITION
@@ -182,15 +182,40 @@ typedef enum {
     // LIFE_CYCLE
     LC_TRANSITION_CNT = 0x3FA8,
     LC_STATE = 0x3FD8
-} fuse_t;
+} fuse_k;
+
+typedef enum {
+    SW_TEST_UNLOCK_PARTITION,
+    SECRET_MANUF_PARTITION,
+    SECRET_PROD_PARTITION_0,
+    SECRET_PROD_PARTITION_1,
+    SECRET_PROD_PARTITION_2,
+    SECRET_PROD_PARTITION_3,
+    SW_MANUF_PARTITION,
+    SECRET_LC_TRANSITION_PARTITION,
+    SVN_PARTITION,
+    VENDOR_TEST_PARTITION,
+    VENDOR_HASHES_MANUF_PARTITION,
+    VENDOR_HASHES_PROD_PARTITION,
+    VENDOR_REVOCATIONS_PROD_PARTITION,
+    VENDOR_SECRET_PROD_PARTITION,
+    VENDOR_NON_SECRET_PROD_PARTITION,
+    LIFE_CYCLE
+} partition_k;
 
 typedef struct {
+    uint32_t index;
     uint32_t address;
     uint32_t digest_address;
+    uint32_t variant;
+    uint32_t granularity;
     bool is_secret;
     bool hw_digest;
     bool sw_digest;
+    bool has_read_lock;
+    bool has_ecc;
     bool is_lifecycle;
+    uint32_t lc_phase;
     uint32_t num_fuses;
     uint32_t *fuses;
 } partition_t;
@@ -382,180 +407,276 @@ uint32_t life_cycle_fuses[] = {
 partition_t partitions[NUM_PARTITIONS] = {
     // SW_TEST_UNLOCK_PARTITION
     {
+        .index = 0,
         .address = 0x0000,
         .digest_address = 0x0040,
+        .variant = 0,
+        .granularity = 32,
         .is_secret = false,
         .hw_digest = true,
         .sw_digest = false,
+        .has_read_lock = false,
+        .has_ecc = true,
+        .lc_phase = 16,
         .is_lifecycle = false,
         .num_fuses = 1,
         .fuses = sw_test_unlock_partition_fuses
     },
     // SECRET_MANUF_PARTITION
     {
+        .index = 1,
         .address = 0x0048,
         .digest_address = 0x0088,
+        .variant = 0,
+        .granularity = 64,
         .is_secret = true,
         .hw_digest = true,
         .sw_digest = false,
+        .has_read_lock = false,
+        .has_ecc = true,
+        .lc_phase = 16,
         .is_lifecycle = false,
         .num_fuses = 1,
         .fuses = secret_manuf_partition_fuses
     },
     // SECRET_PROD_PARTITION_0
     {
+        .index = 2,
         .address = 0x0090,
         .digest_address = 0x0098,
+        .variant = 0,
+        .granularity = 64,
         .is_secret = true,
         .hw_digest = true,
         .sw_digest = false,
+        .has_read_lock = false,
+        .has_ecc = true,
+        .lc_phase = 17,
         .is_lifecycle = false,
         .num_fuses = 1,
         .fuses = secret_prod_partition_0_fuses
     },
     // SECRET_PROD_PARTITION_1
     {
+        .index = 3,
         .address = 0x00A0,
         .digest_address = 0x00A8,
+        .variant = 0,
+        .granularity = 64,
         .is_secret = true,
         .hw_digest = true,
         .sw_digest = false,
+        .has_read_lock = false,
+        .has_ecc = true,
+        .lc_phase = 17,
         .is_lifecycle = false,
         .num_fuses = 1,
         .fuses = secret_prod_partition_1_fuses
     },
     // SECRET_PROD_PARTITION_2
     {
+        .index = 4,
         .address = 0x00B0,
         .digest_address = 0x00B8,
+        .variant = 0,
+        .granularity = 64,
         .is_secret = true,
         .hw_digest = true,
         .sw_digest = false,
+        .has_read_lock = false,
+        .has_ecc = true,
+        .lc_phase = 17,
         .is_lifecycle = false,
         .num_fuses = 1,
         .fuses = secret_prod_partition_2_fuses
     },
     // SECRET_PROD_PARTITION_3
     {
+        .index = 5,
         .address = 0x00C0,
         .digest_address = 0x00C8,
+        .variant = 0,
+        .granularity = 64,
         .is_secret = true,
         .hw_digest = true,
         .sw_digest = false,
+        .has_read_lock = false,
+        .has_ecc = true,
+        .lc_phase = 17,
         .is_lifecycle = false,
         .num_fuses = 1,
         .fuses = secret_prod_partition_3_fuses
     },
     // SW_MANUF_PARTITION
     {
+        .index = 6,
         .address = 0x00D0,
         .digest_address = 0x2C10,
+        .variant = 1,
+        .granularity = 32,
         .is_secret = false,
         .hw_digest = false,
         .sw_digest = true,
+        .has_read_lock = true,
+        .has_ecc = true,
+        .lc_phase = 16,
         .is_lifecycle = false,
         .num_fuses = 12,
         .fuses = sw_manuf_partition_fuses
     },
     // SECRET_LC_TRANSITION_PARTITION
     {
+        .index = 7,
         .address = 0x2C18,
         .digest_address = 0x2CC8,
+        .variant = 0,
+        .granularity = 64,
         .is_secret = true,
         .hw_digest = true,
         .sw_digest = false,
+        .has_read_lock = false,
+        .has_ecc = true,
+        .lc_phase = 1,
         .is_lifecycle = false,
         .num_fuses = 11,
         .fuses = secret_lc_transition_partition_fuses
     },
     // SVN_PARTITION
     {
+        .index = 8,
         .address = 0x2CD0,
         .digest_address = 0x0000,
+        .variant = 1,
+        .granularity = 32,
         .is_secret = false,
         .hw_digest = false,
         .sw_digest = false,
+        .has_read_lock = true,
+        .has_ecc = false,
+        .lc_phase = 17,
         .is_lifecycle = false,
         .num_fuses = 3,
         .fuses = svn_partition_fuses
     },
     // VENDOR_TEST_PARTITION
     {
+        .index = 9,
         .address = 0x2CF8,
         .digest_address = 0x2D30,
+        .variant = 1,
+        .granularity = 32,
         .is_secret = false,
         .hw_digest = false,
         .sw_digest = true,
+        .has_read_lock = true,
+        .has_ecc = false,
+        .lc_phase = 17,
         .is_lifecycle = false,
         .num_fuses = 1,
         .fuses = vendor_test_partition_fuses
     },
     // VENDOR_HASHES_MANUF_PARTITION
     {
+        .index = 10,
         .address = 0x2D38,
         .digest_address = 0x2D70,
+        .variant = 1,
+        .granularity = 32,
         .is_secret = false,
         .hw_digest = false,
         .sw_digest = true,
+        .has_read_lock = true,
+        .has_ecc = false,
+        .lc_phase = 16,
         .is_lifecycle = false,
         .num_fuses = 2,
         .fuses = vendor_hashes_manuf_partition_fuses
     },
     // VENDOR_HASHES_PROD_PARTITION
     {
+        .index = 11,
         .address = 0x2D78,
         .digest_address = 0x3060,
+        .variant = 1,
+        .granularity = 32,
         .is_secret = false,
         .hw_digest = false,
         .sw_digest = true,
+        .has_read_lock = true,
+        .has_ecc = false,
+        .lc_phase = 17,
         .is_lifecycle = false,
         .num_fuses = 31,
         .fuses = vendor_hashes_prod_partition_fuses
     },
     // VENDOR_REVOCATIONS_PROD_PARTITION
     {
+        .index = 12,
         .address = 0x3068,
         .digest_address = 0x30F8,
+        .variant = 1,
+        .granularity = 32,
         .is_secret = false,
         .hw_digest = false,
         .sw_digest = true,
+        .has_read_lock = true,
+        .has_ecc = false,
+        .lc_phase = 17,
         .is_lifecycle = false,
         .num_fuses = 48,
         .fuses = vendor_revocations_prod_partition_fuses
     },
     // VENDOR_SECRET_PROD_PARTITION
     {
+        .index = 13,
         .address = 0x3100,
         .digest_address = 0x3300,
+        .variant = 0,
+        .granularity = 64,
         .is_secret = true,
         .hw_digest = true,
         .sw_digest = false,
+        .has_read_lock = false,
+        .has_ecc = true,
+        .lc_phase = 17,
         .is_lifecycle = false,
         .num_fuses = 16,
         .fuses = vendor_secret_prod_partition_fuses
     },
     // VENDOR_NON_SECRET_PROD_PARTITION
     {
+        .index = 14,
         .address = 0x3308,
         .digest_address = 0x3FA0,
+        .variant = 1,
+        .granularity = 32,
         .is_secret = false,
         .hw_digest = false,
         .sw_digest = true,
+        .has_read_lock = true,
+        .has_ecc = true,
+        .lc_phase = 17,
         .is_lifecycle = false,
         .num_fuses = 16,
         .fuses = vendor_non_secret_prod_partition_fuses
     },
     // LIFE_CYCLE
     {
+        .index = 15,
         .address = 0x3FA8,
         .digest_address = 0x0000,
+        .variant = 2,
+        .granularity = 32,
         .is_secret = false,
         .hw_digest = false,
         .sw_digest = false,
+        .has_read_lock = false,
+        .has_ecc = true,
+        .lc_phase = 0,
         .is_lifecycle = true,
-        .num_fuses = 2,
+        .num_fuses = 1,
         .fuses = life_cycle_fuses
-    }
+    },
 };
 
 #endif // FUSE_CTRL_MMAP_HEADER

--- a/src/integration/test_suites/caliptra_ss_fuse_ctrl_init_fail/caliptra_ss_fuse_ctrl_init_fail.c
+++ b/src/integration/test_suites/caliptra_ss_fuse_ctrl_init_fail/caliptra_ss_fuse_ctrl_init_fail.c
@@ -27,6 +27,7 @@
 #include "caliptra_ss_lib.h"
 #include "fuse_ctrl.h"
 #include "lc_ctrl.h"
+#include "fuse_ctrl_mmap.h"
 
 volatile char* stdout = (char *)SOC_MCI_TOP_MCI_REG_DEBUG_OUT;
 #ifdef CPT_VERBOSITY
@@ -39,11 +40,11 @@ typedef struct {
     uint32_t address;
     uint32_t digest_address;
     uint32_t index;
-} partition_t;
+} partition_tt;
 
 // XXX: Fuse addresses, eventually these should be generated automatically.
 // Buffered partitions.
-static partition_t partitions[7] = {
+static partition_tt partitions_t[7] = {
      // SECRET_MANUF_PARTITION
     { .address = 0x0048, .digest_address = 0x0088, .index = 1 },
     // SECRET_PROD_PARTITION_0
@@ -66,8 +67,8 @@ void init_fail() {
         CMD_FC_LCC_UNCORRECTABLE_FAULT
     };
 
-    partition_t partition = partitions[xorshift32() % 7];
-    uint32_t fault = faults[xorshift32() % 2];
+    partition_tt partition = partitions_t[5];
+    uint32_t fault = faults[1];
 
     if (partition.address > 0x40 && partition.address < 0xD0) {
         grant_caliptra_core_for_fc_writes();

--- a/src/integration/test_suites/caliptra_ss_fuse_ctrl_interrupts/caliptra_ss_fuse_ctrl_interrupts.c
+++ b/src/integration/test_suites/caliptra_ss_fuse_ctrl_interrupts/caliptra_ss_fuse_ctrl_interrupts.c
@@ -27,6 +27,7 @@
 #include "caliptra_ss_lib.h"
 #include "fuse_ctrl.h"
 #include "lc_ctrl.h"
+#include "fuse_ctrl_mmap.h"
 
 volatile char* stdout = (char *)SOC_MCI_TOP_MCI_REG_DEBUG_OUT;
 #ifdef CPT_VERBOSITY
@@ -56,7 +57,7 @@ void main (void) {
      * 1: An ordinary, successful DAI operation must result in an `otp_operation_done` interrupt.
      */
 
-    dai_wr(0x000, 0x1, 0, 32, 0);
+    dai_wr(CPTRA_CORE_MANUF_DEBUG_UNLOCK_TOKEN, 0x1, 0, 32, 0);
 
     uint32_t alert_state = lsu_read_32(SOC_OTP_CTRL_INTERRUPT_STATE);
     if (((alert_state >> OTP_CTRL_INTERRUPT_STATE_OTP_OPERATION_DONE_LOW) & 0x1 != 0x1) ||
@@ -71,7 +72,7 @@ void main (void) {
      */
 
     grant_mcu_for_fc_writes();
-    dai_wr(0x048, 0x1, 0x1, 64, OTP_CTRL_STATUS_DAI_ERROR_MASK); // invalid AXI ID
+    dai_wr(CPTRA_CORE_UDS_SEED, 0x1, 0x1, 64, OTP_CTRL_STATUS_DAI_ERROR_MASK); // invalid AXI ID
 
     alert_state = lsu_read_32(SOC_OTP_CTRL_INTERRUPT_STATE);
     if (((alert_state >> OTP_CTRL_INTERRUPT_STATE_OTP_OPERATION_DONE_LOW) & 0x1 != 0x1) ||

--- a/src/integration/test_suites/caliptra_ss_fuse_ctrl_test_unlocked0_prov/caliptra_ss_fuse_ctrl_test_unlocked0_prov.c
+++ b/src/integration/test_suites/caliptra_ss_fuse_ctrl_test_unlocked0_prov/caliptra_ss_fuse_ctrl_test_unlocked0_prov.c
@@ -28,6 +28,7 @@
 #include "caliptra_ss_lib.h"
 #include "fuse_ctrl.h"
 #include "lc_ctrl.h"
+#include "fuse_ctrl_mmap.h"
 
 volatile char* stdout = (char *)SOC_MCI_TOP_MCI_REG_DEBUG_OUT;
 #ifdef CPT_VERBOSITY
@@ -35,76 +36,6 @@ volatile char* stdout = (char *)SOC_MCI_TOP_MCI_REG_DEBUG_OUT;
 #else
     enum printf_verbosity verbosity_g = LOW;
 #endif
-
-// XXX: Fuse addresses, eventually these should be generated automatically.
-static uint32_t _addr0[] = { 0x000 };
-static uint32_t _addr1[] = { 0x048 };
-static uint32_t _addr2[] = { 0x090 };
-static uint32_t _addr3[] = { 0x0A0 };
-static uint32_t _addr4[] = { 0x0B0 };
-static uint32_t _addr5[] = { 0x0C0 };
-static uint32_t _addr6[] = { 0x0D0, 0x0D1, 0x1FE1, 0x1FF1, 0x1FF3, 0x2023, 0x2053, 0x2083, 0x20B3, 0x20E3, 0x2113, 0x2143 };
-static uint32_t _addr7[] = { 0x2C18, 0x2C28, 0x2C38, 0x2C48, 0x2C58, 0x2C68, 0x2C78, 0x2C88, 0x2C98, 0x2CA8, 0x2CB8 };
-static uint32_t _addr8[] = { 0x2D38, 0x2D68 };
-static uint32_t _addr9[] = { 
-    0x2D78, 0x2DA8, 0x2DA9, 0x2DD9, 0x2DDA, 0x2E0A, 0x2E0B, 0x2E3B, 0x2E3C, 0x2E6C, 0x2E6D, 0x2E9D,
-    0x2E9E, 0x2ECE, 0x2ECF, 0x2EFF, 0x2F00, 0x2F30, 0x2F31, 0x2F61, 0x2F62, 0x2F92, 0x2F93, 0x2FC3,
-    0x2FC4, 0x2FF4, 0x2FF5, 0x3025, 0x3026, 0x3056, 0x3057
-};
-static uint32_t _addr10[] = { 
-    0x3068, 0x3069, 0x306D, 0x3071, 0x3072, 0x3076, 0x307A, 0x307B, 0x307F, 0x3083, 0x3084, 0x3088,
-    0x308C, 0x308D, 0x3091, 0x3095, 0x3096, 0x309A, 0x309E, 0x309F, 0x30A3, 0x30A7, 0x30A8, 0x30AC,
-    0x30B0, 0x30B1, 0x30B5, 0x30B9, 0x30BA, 0x30BE, 0x30C2, 0x30C3, 0x30C7, 0x30CB, 0x30CC, 0x30D0,
-    0x30D4, 0x30D5, 0x30D9, 0x30DD, 0x30DE, 0x30E2, 0x30E6, 0x30E7, 0x30EB, 0x30EF, 0x30F0, 0x30F4
-};
-static uint32_t _addr11[] = { 
-    0x3100, 0x3120, 0x3140, 0x3160, 0x3180, 0x31A0, 0x31C0, 0x31E0, 0x3200, 0x3220, 0x3240, 0x3260,
-    0x3280, 0x32A0, 0x32C0, 0x32E0
-};
-static uint32_t _addr12[] = { 
-    0x3308, 0x3328, 0x3348, 0x3368, 0x3388, 0x33A8, 0x33C8, 0x33E8, 0x3408, 0x3428, 0x3448,
-    0x3468, 0x3488, 0x34A8, 0x34C8, 0x34E8
-};
-
-typedef struct {
-    uint32_t address;
-    uint32_t granularity;
-    bool is_software;
-
-    uint32_t num_fuses;
-    uint32_t *fuse_addresses;
-    uint32_t digest_address;
-} partition_t;
-
-// XXX: Fuse addresses, eventually these should be generated automatically.
-static partition_t partitions[13] = {
-    // SECRET_TEST_UNLOCK_PARTITION
-    { .address = 0x000, .granularity = 32, .is_software = false, .num_fuses = 1,  .fuse_addresses = _addr0, .digest_address = 0x040 },
-     // SECRET_MANUF_PARTITION
-    { .address = 0x048, .granularity = 64, .is_software = false, .num_fuses = 1,  .fuse_addresses = _addr1, .digest_address = 0x088 },
-    // SECRET_PROD_PARTITION_0
-    { .address = 0x090, .granularity = 64, .is_software = false, .num_fuses = 1,  .fuse_addresses = _addr2, .digest_address = 0x098 },
-    // SECRET_PROD_PARTITION_1 
-    { .address = 0x0A0, .granularity = 64, .is_software = false, .num_fuses = 1,  .fuse_addresses = _addr3, .digest_address = 0x0A8 },
-    // SECRET_PROD_PARTITION_2 
-    { .address = 0x0B0, .granularity = 64, .is_software = false, .num_fuses = 1,  .fuse_addresses = _addr4, .digest_address = 0x0B8 },
-    // SECRET_PROD_PARTITION_3
-    { .address = 0x0C0, .granularity = 64, .is_software = false, .num_fuses = 1,  .fuse_addresses = _addr5, .digest_address = 0x0C8 },
-    // SW_MANUF_PARTITION
-    { .address = 0x0D0, .granularity = 32, .is_software = true,  .num_fuses = 5,  .fuse_addresses = _addr6, .digest_address = 0x2C10 }, 
-    // SECRET_LC_TRANSITION_PARTITION
-    { .address = 0x2C18, .granularity = 64, .is_software = false, .num_fuses = 11, .fuse_addresses = _addr7, .digest_address = 0x2CC8 },  
-    // VENDOR_HASHES_MANUF_PARTITION
-    { .address = 0x2D38, .granularity = 32, .is_software = true,  .num_fuses = 2,  .fuse_addresses = _addr8, .digest_address = 0x2D70 }, 
-    // VENDOR_HASHES_PROD_PARTITION
-    { .address = 0x2D78, .granularity = 32, .is_software = true,  .num_fuses = 31, .fuse_addresses = _addr9, .digest_address = 0x3060 }, 
-    // VENDOR_REVOCATIONS_PROD_PARTITION
-    { .address = 0x3068, .granularity = 32, .is_software = true,  .num_fuses = 48, .fuse_addresses = _addr10, .digest_address = 0x30F8 }, 
-    // VENDOR_SECRET_PROD_PARTITION
-    { .address = 0x3100, .granularity = 64, .is_software = false, .num_fuses = 16, .fuse_addresses = _addr11, .digest_address = 0x3300 },
-    // VENDOR_NON_SECRET_PROD_PARTITION
-    { .address = 0x3308, .granularity = 64, .is_software = true,  .num_fuses = 16, .fuse_addresses = _addr12, .digest_address = 0x3FA0 }, 
-};
 
 void test_unlocked0_provision() {
     const uint32_t sentinel = 0xA5;
@@ -117,16 +48,16 @@ void test_unlocked0_provision() {
     }
 
     uint32_t read_value, zero;
-    uint32_t rnd_fuse_addresses[13];
+    uint32_t rnd_fuse_addresses[NUM_PARTITIONS-1];
 
-    for (uint32_t i = 0; i < 13; i++) {
+    for (uint32_t i = 0; i < (NUM_PARTITIONS-1); i++) {
         if (partitions[i].address > 0x40 && partitions[i].address < 0xD0) {
             grant_caliptra_core_for_fc_writes();
         } else {
             grant_mcu_for_fc_writes(); 
         }
 
-        rnd_fuse_addresses[i] = partitions[i].fuse_addresses[xorshift32() % partitions[i].num_fuses];
+        rnd_fuse_addresses[i] = partitions[i].fuses[xorshift32() % partitions[i].num_fuses];
         
         dai_wr(rnd_fuse_addresses[i], sentinel, 0, partitions[i].granularity, 0);
         
@@ -135,7 +66,7 @@ void test_unlocked0_provision() {
             VPRINTF(LOW, "ERROR: incorrect value: exp: %08X act: %08X\n", read_value, sentinel);
         }
 
-        if (partitions[i].is_software) {
+        if (!partitions[i].is_secret) {
             dai_wr(partitions[i].digest_address, sentinel, 0, 64, 0);
         } else {
             calculate_digest(partitions[i].address);
@@ -145,7 +76,7 @@ void test_unlocked0_provision() {
     reset_fc_lcc_rtl();
     wait_dai_op_idle(0);
 
-    for (uint32_t i = 0; i < 13; i++) {
+    for (uint32_t i = 0; i < (NUM_PARTITIONS-1); i++) {
         if (partitions[i].address > 0x40 && partitions[i].address < 0xD0) {
             grant_caliptra_core_for_fc_writes();
         } else {
@@ -154,7 +85,7 @@ void test_unlocked0_provision() {
 
         dai_wr(rnd_fuse_addresses[i], sentinel, 0, partitions[i].granularity, OTP_CTRL_STATUS_DAI_ERROR_MASK);
         
-        if (partitions[i].is_software) {
+        if (!partitions[i].is_secret) {
             dai_rd(rnd_fuse_addresses[i], &read_value, &zero, partitions[i].granularity, 0);
             if ((read_value & 0xFF) != sentinel) {
                 VPRINTF(LOW, "ERROR: incorrect value: exp: %08X act: %08X\n", read_value, sentinel);

--- a/src/integration/test_suites/caliptra_ss_fuse_ctrl_test_unlocked0_prov/caliptra_ss_fuse_ctrl_test_unlocked0_prov.c
+++ b/src/integration/test_suites/caliptra_ss_fuse_ctrl_test_unlocked0_prov/caliptra_ss_fuse_ctrl_test_unlocked0_prov.c
@@ -79,7 +79,7 @@ typedef struct {
 // XXX: Fuse addresses, eventually these should be generated automatically.
 static partition_t partitions[13] = {
     // SECRET_TEST_UNLOCK_PARTITION
-    { .address = 0x000, .granularity = 32, .is_software = true, .num_fuses = 1,  .fuse_addresses = _addr0, .digest_address = 0x040 },
+    { .address = 0x000, .granularity = 32, .is_software = false, .num_fuses = 1,  .fuse_addresses = _addr0, .digest_address = 0x040 },
      // SECRET_MANUF_PARTITION
     { .address = 0x048, .granularity = 64, .is_software = false, .num_fuses = 1,  .fuse_addresses = _addr1, .digest_address = 0x088 },
     // SECRET_PROD_PARTITION_0

--- a/src/integration/test_suites/caliptra_ss_fuse_ctrl_volatile_lock/caliptra_ss_fuse_ctrl_volatile_lock.c
+++ b/src/integration/test_suites/caliptra_ss_fuse_ctrl_volatile_lock/caliptra_ss_fuse_ctrl_volatile_lock.c
@@ -27,6 +27,7 @@
 #include "caliptra_ss_lib.h"
 #include "fuse_ctrl.h"
 #include "lc_ctrl.h"
+#include "fuse_ctrl_mmap.h"
 
 volatile char* stdout = (char *)SOC_MCI_TOP_MCI_REG_DEBUG_OUT;
 #ifdef CPT_VERBOSITY
@@ -39,9 +40,9 @@ void pk_volatile_lock(void) {
     // Loop through all possible pk volatile locks.
     for (uint32_t i = 1; i < 15; i++) {
         lsu_write_32(SOC_OTP_CTRL_VENDOR_PK_HASH_VOLATILE_LOCK, i);
-        dai_wr(0x2D78 + i*49, 0xFF, 0, 32, OTP_CTRL_STATUS_DAI_ERROR_MASK);
+        dai_wr(CPTRA_CORE_VENDOR_PK_HASH_1 + i*49, 0xFF, 0, 32, OTP_CTRL_STATUS_DAI_ERROR_MASK);
         lsu_write_32(SOC_OTP_CTRL_VENDOR_PK_HASH_VOLATILE_LOCK, 0);
-        dai_wr(0x2D78 + i*49, 0xFF, 0, 32, 0);
+        dai_wr(CPTRA_CORE_VENDOR_PK_HASH_1 + i*49, 0xFF, 0, 32, 0);
     }
 }
 

--- a/src/integration/test_suites/caliptra_ss_fuse_ctrl_writeblank/caliptra_ss_fuse_ctrl_writeblank.c
+++ b/src/integration/test_suites/caliptra_ss_fuse_ctrl_writeblank/caliptra_ss_fuse_ctrl_writeblank.c
@@ -39,8 +39,7 @@ volatile char* stdout = (char *)SOC_MCI_TOP_MCI_REG_DEBUG_OUT;
 void writeblank() {
     grant_mcu_for_fc_writes();
 
-    // 0x2CD0: CPTRA_CORE_FMC_KEY_MANIFEST_SVN
-    const uint32_t fuse_address = 0x2CD0;
+    const uint32_t fuse_address = CPTRA_CORE_FMC_KEY_MANIFEST_SVN;
 
     // Overwriting set bits in a fuse should result in an error.
     dai_wr(fuse_address, 0xFFFFFFFF, 0, 32, 0);

--- a/src/integration/test_suites/caliptra_ss_lcc_st_trans/caliptra_ss_lcc_st_trans.c
+++ b/src/integration/test_suites/caliptra_ss_lcc_st_trans/caliptra_ss_lcc_st_trans.c
@@ -72,6 +72,11 @@ void main (void) {
         VPRINTF(LOW, "INFO: current lcc state: %d\n", lc_state_curr);
         VPRINTF(LOW, "INFO: current lc cntc state: %d\n", lc_cnt_curr);
 
+        if (lc_cnt_curr == 24) {
+            VPRINTF(LOW, "INFO: reached max. LC counter value, finish test test\n");
+            goto epilogue;
+        }
+
         uint32_t count = 0;
         memset(buf, 0, sizeof(buf));
         for (uint32_t i = 1, k = 0; (i + lc_state_curr)< NUM_LC_STATES; i++) {

--- a/src/integration/test_suites/smoke_test_fc_debug_unlock_token/smoke_test_fc_debug_unlock_token.c
+++ b/src/integration/test_suites/smoke_test_fc_debug_unlock_token/smoke_test_fc_debug_unlock_token.c
@@ -27,6 +27,7 @@
 #include "caliptra_ss_lib.h"
 #include "fuse_ctrl.h"
 #include "lc_ctrl.h"
+#include "fuse_ctrl_mmap.h"
 
 volatile char* stdout = (char *)SOC_MCI_TOP_MCI_REG_DEBUG_OUT;
 #ifdef CPT_VERBOSITY
@@ -49,9 +50,9 @@ void main (void) {
     
     initialize_otp_controller();
 
-    const uint32_t base_address = 0x0000;
-    const uint32_t fuse_address = 0x0000;
-    const uint32_t digest_address = 0x0040;
+    const uint32_t base_address = CPTRA_CORE_MANUF_DEBUG_UNLOCK_TOKEN;
+    const uint32_t fuse_address = base_address;
+    const uint32_t digest_address = SW_TEST_UNLOCK_PARTITION_DIGEST;
 
     const uint32_t sentinel = 0xAB;
 

--- a/src/integration/test_suites/smoke_test_fc_key_revocation/smoke_test_fc_key_revocation.c
+++ b/src/integration/test_suites/smoke_test_fc_key_revocation/smoke_test_fc_key_revocation.c
@@ -27,6 +27,7 @@
 #include "caliptra_ss_lib.h"
 #include "fuse_ctrl.h"
 #include "lc_ctrl.h"
+#include "fuse_ctrl_mmap.h"
 
 volatile char* stdout = (char *)SOC_MCI_TOP_MCI_REG_DEBUG_OUT;
 #ifdef CPT_VERBOSITY
@@ -53,9 +54,8 @@ volatile char* stdout = (char *)SOC_MCI_TOP_MCI_REG_DEBUG_OUT;
  */
 void vendor_revocations_prod_partition() {
 
-    // 0x3068: CPTRA_CORE_ECC_REVOCATION_0
-    const uint32_t base_address = 0x3068;
-    const uint32_t digest_address = 0x30F8;
+    const uint32_t base_address = CPTRA_CORE_ECC_REVOCATION_0;
+    const uint32_t digest_address = VENDOR_REVOCATIONS_PROD_PARTITION_DIGEST;
     const uint32_t fuse_address = base_address;
 
     const uint32_t data = 0xdeadbeef;

--- a/src/integration/test_suites/smoke_test_fc_pk_volatile_lock/smoke_test_fc_pk_volatile_lock.c
+++ b/src/integration/test_suites/smoke_test_fc_pk_volatile_lock/smoke_test_fc_pk_volatile_lock.c
@@ -27,6 +27,7 @@
 #include "caliptra_ss_lib.h"
 #include "fuse_ctrl.h"
 #include "lc_ctrl.h"
+#include "fuse_ctrl_mmap.h"
 
 volatile char* stdout = (char *)SOC_MCI_TOP_MCI_REG_DEBUG_OUT;
 #ifdef CPT_VERBOSITY
@@ -46,10 +47,7 @@ volatile char* stdout = (char *)SOC_MCI_TOP_MCI_REG_DEBUG_OUT;
  *   4. Verify that writing to the second fuse now results in an error.
  */
 void program_vendor_hashes_prod_partition(void) {
-
-    // 0x2DDA: CPTRA_CORE_VENDOR_PK_HASH_3
-    // 0x2E3C: CPTRA_CORE_VENDOR_PK_HASH_5
-    const uint32_t addresses[2] = {0x2DDA, 0x2E3C};
+    const uint32_t addresses[2] = {CPTRA_CORE_VENDOR_PK_HASH_3, CPTRA_CORE_VENDOR_PK_HASH_5};
 
     const uint32_t data = 0xdeadbeef;
 

--- a/src/integration/test_suites/smoke_test_fc_prov_lcc_tokens/smoke_test_fc_prov_lcc_tokens.c
+++ b/src/integration/test_suites/smoke_test_fc_prov_lcc_tokens/smoke_test_fc_prov_lcc_tokens.c
@@ -27,6 +27,7 @@
 #include "caliptra_ss_lib.h"
 #include "fuse_ctrl.h"
 #include "lc_ctrl.h"
+#include "fuse_ctrl_mmap.h"
 
 volatile char* stdout = (char *)SOC_MCI_TOP_MCI_REG_DEBUG_OUT;
 #ifdef CPT_VERBOSITY
@@ -56,9 +57,8 @@ volatile char* stdout = (char *)SOC_MCI_TOP_MCI_REG_DEBUG_OUT;
  */
 void program_secret_lc_transition_partition() {
 
-    // 0x2C88: CPTRA_SS_TEST_EXIT_TO_MANUF_TOKEN
-    const uint32_t base_address = 0x2C18;
-    const uint32_t fuse_address = 0x2C88;
+    const uint32_t base_address = partitions[SECRET_LC_TRANSITION_PARTITION].address;
+    const uint32_t fuse_address = CPTRA_SS_TEST_EXIT_TO_MANUF_TOKEN;
 
     const uint32_t data[4] = {0xdeadbeef, 0xcafebabe, 0x12345678, 0xabababab};
     uint32_t read_data[4];

--- a/src/integration/test_suites/smoke_test_fc_registers/smoke_test_fc_registers.c
+++ b/src/integration/test_suites/smoke_test_fc_registers/smoke_test_fc_registers.c
@@ -27,6 +27,7 @@
 #include "caliptra_ss_lib.h"
 #include "fuse_ctrl.h"
 #include "lc_ctrl.h"
+#include "fuse_ctrl_mmap.h"
 
 volatile char* stdout = (char *)SOC_MCI_TOP_MCI_REG_DEBUG_OUT;
 #ifdef CPT_VERBOSITY
@@ -49,9 +50,7 @@ volatile char* stdout = (char *)SOC_MCI_TOP_MCI_REG_DEBUG_OUT;
  *  5. Check that a read now results in an error.
  */
 void register_accesses() {
-
-    // 0x3068: CPTRA_CORE_ECC_REVOCATION_0
-    const uint32_t fuse_address = 0x3068;
+    const uint32_t fuse_address = CPTRA_CORE_ECC_REVOCATION_0;
 
     const uint32_t data = 0xdeadbeef;
     uint32_t read_data;

--- a/src/integration/test_suites/smoke_test_fc_unlock_transitions/smoke_test_fc_unlock_transitions.c
+++ b/src/integration/test_suites/smoke_test_fc_unlock_transitions/smoke_test_fc_unlock_transitions.c
@@ -27,6 +27,7 @@
 #include "caliptra_ss_lib.h"
 #include "fuse_ctrl.h"
 #include "lc_ctrl.h"
+#include "fuse_ctrl_mmap.h"
 
 volatile char* stdout = (char *)SOC_MCI_TOP_MCI_REG_DEBUG_OUT;
 #ifdef CPT_VERBOSITY
@@ -65,8 +66,7 @@ static uint32_t hashed_tokens[8][4] = {
  */
 void iterate_test_unlock_states() {
 
-    // 0x2C18: CPTRA_SS_TEST_UNLOCK_TOKEN_1
-    const uint32_t base_address = 0x2C18;
+    const uint32_t base_address = CPTRA_SS_TEST_UNLOCK_TOKEN_1;
 
     // Write the tokens into the partition.
     for (uint32_t i = 0; i < 3; i++) {

--- a/src/integration/testbench/fc_lcc_tb_services.sv
+++ b/src/integration/testbench/fc_lcc_tb_services.sv
@@ -244,10 +244,10 @@ module fc_lcc_tb_services (
   //-------------------------------------------------------------------------
 
   reg fault_active_q;
-  reg [15:0] faulted_word_q [0:7];
+  reg [15:0] faulted_word_q [0:6];
 
-  localparam int partition_offsets [0:7] = '{'h000, 'h024, 'h048, 'h050, 'h058, 'h060, 'h260, 'h4D4};
-  localparam int partition_digests [0:7] = '{'h020, 'h044, 'h04C, 'h054, 'h05C, 'h064, 'h2B8, 'h5D4};
+  localparam int partition_offsets [0:6] = '{'h024, 'h048, 'h050, 'h058, 'h060, 'h160C, 'h1880};
+  localparam int partition_digests [0:6] = '{'h044, 'h04C, 'h054, 'h05C, 'h064, 'h1664, 'h1980};
 
   always_ff @(posedge clk or negedge cptra_rst_b) begin
     if (!cptra_rst_b) begin
@@ -260,7 +260,7 @@ module fc_lcc_tb_services (
   end
 
   generate
-  for (genvar i = 0; i < 8; i++) begin
+  for (genvar i = 0; i < 7; i++) begin
     always_ff @(posedge clk or negedge cptra_rst_b) begin
       if (!cptra_rst_b) begin
         faulted_word_q[i] <= '0;
@@ -279,7 +279,7 @@ module fc_lcc_tb_services (
   endgenerate
 
   generate
-  for (genvar i = 0; i < 8; i++) begin
+  for (genvar i = 0; i < 7; i++) begin
     always_comb begin
       if (fault_active_q) begin
         force `FC_MEM[partition_offsets[i]][15:0] = faulted_word_q[i];

--- a/tools/scripts/Makefile
+++ b/tools/scripts/Makefile
@@ -75,6 +75,7 @@ COMP_LIB_NAMES := caliptra_ss_lib \
 COMP_LIBS := $(foreach name, $(COMP_LIB_NAMES), $(LIBS_DIR)/$(name))
 HEADER_FILES := $(RTL_DIR)/soc_address_map.h \
 		$(RTL_DIR)/fuse_ctrl_address_map.h \
+		$(RTL_DIR)/fuse_ctrl_mmap.h \
 		$(RTL_DIR)/caliptra_ss_lc_ctrl_address_map.h \
 		$(INCLUDES_DIR)/caliptra_ss_defines.h \
 		$(RISCV_HW_IF_DIR)/riscv_hw_if.h \

--- a/tools/scripts/fuse_ctrl_script/gen_fuse_ctrl_partitions.py
+++ b/tools/scripts/fuse_ctrl_script/gen_fuse_ctrl_partitions.py
@@ -55,6 +55,7 @@ REG_TOP_TEMPLATE  = "reg_top.sv.tpl"
 
 # C templates
 C_HEADER_TEMPLATE = "fuse_ctrl_address_map.h.tpl"
+C_MMAP_TEMPLATE   = "fuse_ctrl_mmap.h.tpl"
 
 def render_template(template: str, target_path: Path, params: Dict[str, object]):
     try:
@@ -164,6 +165,12 @@ def main():
         template=TEMPLATES_PATH / C_HEADER_TEMPLATE,
         target_path=C_OUTPUT_PATH / C_HEADER_TEMPLATE.replace(".tpl", ""),
         params={"rb": ip_block.reg_blocks["core"]}
+    )
+
+    render_template(
+        template=TEMPLATES_PATH / C_MMAP_TEMPLATE,
+        target_path=C_OUTPUT_PATH / C_MMAP_TEMPLATE.replace(".tpl", ""),
+        params={"partitions": otp_mmap.config["partitions"]}
     )
 
 if __name__ == "__main__":


### PR DESCRIPTION
Automatically generate MMAP definitions for the testsuite instead of hardcoding them within the tests themselves. This will increase the resilience of the testsuite against changes in the MMAP (such as changing the size of a a fuse).

#### Under the hood:

The partition generation script `./tools/scripts/fuse_ctrl_script/gen_fuse_ctrl_partitions.py` now also outputs a C header file `src/integration/rtl/fuse_ctrl_mmap.h` that contains all the relevant partition parameters and fuse addresses.