### PR TITLE
[OCP LOCK] Add FC Ratchet Seed Memory Map.

### DIFF
--- a/src/fuse_ctrl/data/otp_ctrl_mmap.hjson
+++ b/src/fuse_ctrl/data/otp_ctrl_mmap.hjson
@@ -28,7 +28,7 @@
         key_size:  "16",
         iv_size:   "8",
         cnst_size: "16",
-        keys: [  
+        keys: [
             {
                 name:  "SecretManufKey",
                 value: "<random>",
@@ -92,7 +92,7 @@
                     desc: '''
                     Hashed, Non-secret, value for manufacturing debug unlock authorization.
                     '''
-                },                
+                },
             ],
             desc: '''Software manufacturing partition.
             '''
@@ -119,7 +119,7 @@
                     DICE Unique Device Secret Seed.
                     This seed is unique per device. The seed is scrambled using an obfuscation function.
                     '''
-                },            
+                },
             ],
             desc: '''Secret manufacturing partition.
             '''
@@ -470,7 +470,7 @@
                     desc: '''
                     Used to transition the device to the RMA state.
                     '''
-                },                                        
+                },
             ],
             desc: '''Secret life-cycle unlock token partition.
             '''
@@ -518,7 +518,7 @@
                     desc: '''
                     Maximum value for the SOC authorization manifest SVN..
                     '''
-                },                   
+                },
             ],
             desc: '''SVN Partition.
             '''
@@ -577,7 +577,7 @@
                     desc: '''
                     One-hot encoded selection of PQC key type for firmware validation. Bit 0 -> MLDSA, Bit 1 -> LMS.
                     '''
-                },                         
+                },
             ],
             desc: '''Vendor hashes manufacturing partition.
             '''
@@ -596,7 +596,7 @@
             bkout_type:   false, // Do not generate a breakout type for this partition.
             lc_phase:     "LcStProd",
             items: [
-                           
+
                 {
                     name: "CPTRA_SS_OWNER_PK_HASH",
                     size: "48",
@@ -621,7 +621,7 @@
                     a volatile lock should be implemented on higher order bits).
                     SoC product requirements determine the need of this partition.
                     '''
-                },   
+                },
                 {
                     name: "CPTRA_CORE_VENDOR_PK_HASH_1",
                     size: "48",
@@ -870,7 +870,7 @@
                     a volatile lock should be implemented on higher order bits).
                     SoC product requirements determine the need of this partition; and the number of public keys required.
                     '''
-                },                                          
+                },
             ],
             desc: '''Vendor hashes production partition.
             '''
@@ -1545,6 +1545,198 @@
             desc: '''Vendor non-secret production partition.
             '''
         },
+        {
+            name: "CPTRA_SS_LOCK_HEK_PROD_0",
+            variant:      "Unbuffered",
+            absorb:       false,
+            secret:       false,
+            sw_digest:    true,
+            hw_digest:    false,
+            write_lock:   "Digest",
+            read_lock:    "CSR",
+            key_sel:      "NoKey",
+            integrity:    true,
+            bkout_type:   false,
+            lc_phase:     "LcStProd",
+            zeroizable:   true,
+            items: [
+               {
+                    name: "CPTRA_SS_LOCK_HEK_PROD_0_RATCHET_SEED",
+                    size: "32",
+                    desc: "OCP L.O.C.K HEK ratchet seed slot 0."
+                },
+            ],
+            desc: '''OCP L.O.C.K Hard Epoch Key (HEK) ratchet seed slot 0.
+            '''
+        },
+        {
+            name: "CPTRA_SS_LOCK_HEK_PROD_1",
+            variant:      "Unbuffered",
+            absorb:       false,
+            secret:       false,
+            sw_digest:    true,
+            hw_digest:    false,
+            write_lock:   "Digest",
+            read_lock:    "CSR",
+            key_sel:      "NoKey",
+            integrity:    true,
+            bkout_type:   false,
+            lc_phase:     "LcStProd",
+            zeroizable:   true,
+            items: [
+               {
+                    name: "CPTRA_SS_LOCK_HEK_PROD_1_RATCHET_SEED",
+                    size: "32",
+                    desc: "OCP L.O.C.K HEK ratchet seed slot 1."
+                },
+            ],
+            desc: '''OCP L.O.C.K Hard Epoch Key (HEK) ratchet seed slot 1.
+            '''
+        },
+        {
+            name: "CPTRA_SS_LOCK_HEK_PROD_2",
+            variant:      "Unbuffered",
+            absorb:       false,
+            secret:       false,
+            sw_digest:    true,
+            hw_digest:    false,
+            write_lock:   "Digest",
+            read_lock:    "CSR",
+            key_sel:      "NoKey",
+            integrity:    true,
+            bkout_type:   false,
+            lc_phase:     "LcStProd",
+            zeroizable:   true,
+            items: [
+               {
+                    name: "CPTRA_SS_LOCK_HEK_PROD_2_RATCHET_SEED",
+                    size: "32",
+                    desc: "OCP L.O.C.K HEK ratchet seed slot 2."
+                },
+            ],
+            desc: '''OCP L.O.C.K Hard Epoch Key (HEK) ratchet seed slot 2.
+            '''
+        },
+        {
+            name: "CPTRA_SS_LOCK_HEK_PROD_3",
+            variant:      "Unbuffered",
+            absorb:       false,
+            secret:       false,
+            sw_digest:    true,
+            hw_digest:    false,
+            write_lock:   "Digest",
+            read_lock:    "CSR",
+            key_sel:      "NoKey",
+            integrity:    true,
+            bkout_type:   false,
+            lc_phase:     "LcStProd",
+            zeroizable:   true,
+            items: [
+               {
+                    name: "CPTRA_SS_LOCK_HEK_PROD_3_RATCHET_SEED",
+                    size: "32",
+                    desc: "OCP L.O.C.K HEK ratchet seed slot 3."
+                },
+            ],
+            desc: '''OCP L.O.C.K Hard Epoch Key (HEK) ratchet seed slot 3.
+            '''
+        },
+        {
+            name: "CPTRA_SS_LOCK_HEK_PROD_4",
+            variant:      "Unbuffered",
+            absorb:       false,
+            secret:       false,
+            sw_digest:    true,
+            hw_digest:    false,
+            write_lock:   "Digest",
+            read_lock:    "CSR",
+            key_sel:      "NoKey",
+            integrity:    true,
+            bkout_type:   false,
+            lc_phase:     "LcStProd",
+            zeroizable:   true,
+            items: [
+               {
+                    name: "CPTRA_SS_LOCK_HEK_PROD_4_RATCHET_SEED",
+                    size: "32",
+                    desc: "OCP L.O.C.K HEK ratchet seed slot 4."
+                },
+            ],
+            desc: '''OCP L.O.C.K Hard Epoch Key (HEK) ratchet seed slot 4.
+            '''
+        },
+        {
+            name: "CPTRA_SS_LOCK_HEK_PROD_5",
+            variant:      "Unbuffered",
+            absorb:       false,
+            secret:       false,
+            sw_digest:    true,
+            hw_digest:    false,
+            write_lock:   "Digest",
+            read_lock:    "CSR",
+            key_sel:      "NoKey",
+            integrity:    true,
+            bkout_type:   false,
+            lc_phase:     "LcStProd",
+            zeroizable:   true,
+            items: [
+               {
+                    name: "CPTRA_SS_LOCK_HEK_PROD_5_RATCHET_SEED",
+                    size: "32",
+                    desc: "OCP L.O.C.K HEK ratchet seed slot 5."
+                },
+            ],
+            desc: '''OCP L.O.C.K Hard Epoch Key (HEK) ratchet seed slot 5.
+            '''
+        },
+        {
+            name: "CPTRA_SS_LOCK_HEK_PROD_6",
+            variant:      "Unbuffered",
+            absorb:       false,
+            secret:       false,
+            sw_digest:    true,
+            hw_digest:    false,
+            write_lock:   "Digest",
+            read_lock:    "CSR",
+            key_sel:      "NoKey",
+            integrity:    true,
+            bkout_type:   false,
+            lc_phase:     "LcStProd",
+            zeroizable:   true,
+            items: [
+               {
+                    name: "CPTRA_SS_LOCK_HEK_PROD_6_RATCHET_SEED",
+                    size: "32",
+                    desc: "OCP L.O.C.K HEK ratchet seed slot 6."
+                },
+            ],
+            desc: '''OCP L.O.C.K Hard Epoch Key (HEK) ratchet seed slot 6.
+            '''
+        }
+        {
+            name: "CPTRA_SS_LOCK_HEK_PROD_7",
+            variant:      "Unbuffered",
+            absorb:       false,
+            secret:       false,
+            sw_digest:    true,
+            hw_digest:    false,
+            write_lock:   "Digest",
+            read_lock:    "CSR",
+            key_sel:      "NoKey",
+            integrity:    true,
+            bkout_type:   false,
+            lc_phase:     "LcStProd",
+            zeroizable:   true,
+            items: [
+               {
+                    name: "CPTRA_SS_LOCK_HEK_PROD_7_RATCHET_SEED",
+                    size: "32",
+                    desc: "OCP L.O.C.K HEK ratchet seed slot 7."
+                },
+            ],
+            desc: '''OCP L.O.C.K Hard Epoch Key (HEK) ratchet seed slot 7.
+            '''
+        }
         {
             name:         "LIFE_CYCLE",
             variant:      "LifeCycle",


### PR DESCRIPTION
The Fuse Controller memory map is updated to include a reference implementation of the OCP L.O.C.K Hard Epoch Key (HEK) ratchet seeds.

Each ratchet seed is 256-bits, and is stored in a software partition to make it accessible to MCU or Core firmware. The seed is wrapped by an obfuscation key, making it safe to be read from the MCU.

Each ratchet seed is stored in a separate fuse partition to provide the following properties:

* Write locking: At fuse programming time by writing a non-zero value to the partition's digest field. The digest is written to fuses.
* Read locking: By write-lockable CSR. The lock is held until the next SS reset.
* Zeroization: Managed by software.

The partitions are placed at the end of the memory map to allow integrators to remove the partition when OCP L.O.C.K functionality is not required.

The naming convention uses the partition name as the prefix for each ratchet seed. This is to also make the autogeneration of digest and zeroization fields more ergonomic for firmware - e.g. `CPTRA_SS_LOCK_HEK_PROD_0_DIGEST` corresponds to the digest field for the `CPTRA_SS_LOCK_HEK_PROD_0` partition.

Depends on the following PRs: 
* https://github.com/chipsalliance/caliptra-ss/pull/518
* https://github.com/chipsalliance/caliptra-ss/pull/579