### PR TITLE
[fuse_ctrl,dv]: Fix FcLockedPartitionWriteLock_A with scrambling

### DIFF
--- a/src/integration/asserts/caliptra_ss_top_sva.sv
+++ b/src/integration/asserts/caliptra_ss_top_sva.sv
@@ -363,16 +363,36 @@ module caliptra_ss_top_sva
     )
 
   // Assert that partitions are write-locked after the digest has been computed.
+  //
+  // Once a partition has a digest (either sw or hw), it should be write-locked. This means that if
+  // we start a DaiWrite operation with an address that points inside that partition, it should
+  // respond with an error.
+  //
+  // Normally, this response will appear in two cycles (with otp_ctrl_dai going to the WriteSt, then
+  // noticing the partition is locked, so setting error_d, which gets flopped to error_o). However,
+  // the partition might be scrambled (visible because PartInfo[part_idx].secret is true). In that
+  // case, there are two extra cycles because the FSM goes through ScrSt, ScrWaitSt first.
+
+  logic        part_may_have_digest, part_has_digest;
+  int unsigned part_digest_word_addr;
+  logic [21:0] raw_part_digest_value;
+  logic        dai_write_req;
+  logic        dai_addr_below_digest;
+  logic        dai_access_error;
+
+  assign part_may_have_digest  = PartInfo[part_idx].hw_digest || PartInfo[part_idx].sw_digest;
+  assign part_digest_word_addr = otp_ctrl_part_pkg::digest_addrs[part_idx] / 2;
+  assign raw_part_digest_value =
+    `CPTRA_SS_TB_TOP_NAME.u_otp.u_prim_ram_1p_adv.u_mem.mem[part_digest_word_addr];
+  assign part_has_digest       = part_may_have_digest && (raw_part_digest_value != 0);
+  assign dai_write_req         = `FC_PATH.dai_req && dai_cmd_e'(`FC_PATH.dai_cmd) == DaiWrite;
+  assign dai_addr_below_digest = (`FC_PATH.dai_addr >= PartInfo[part_idx].offset) &&
+                                 (`FC_PATH.dai_addr < otp_ctrl_part_pkg::digest_addrs[part_idx]);
+  assign dai_access_error = otp_err_e'(`FC_PATH.part_error[DaiIdx]) == AccessError;
+
   `CALIPTRA_ASSERT(FcLockedPartitionWriteLock_A,
-    ((PartInfo[part_idx].hw_digest || PartInfo[part_idx].sw_digest) &&
-     (`CPTRA_SS_TB_TOP_NAME.u_otp.u_prim_ram_1p_adv.u_mem.mem[otp_ctrl_part_pkg::digest_addrs[part_idx]/2] != 0) &&
-     (`FC_PATH.dai_req) &&
-     (dai_cmd_e'(`FC_PATH.dai_cmd) == DaiWrite) &&
-     (`FC_PATH.dai_addr >= PartInfo[part_idx].offset) &&
-     (`FC_PATH.dai_addr < otp_ctrl_part_pkg::digest_addrs[part_idx]))
-     |-> ##2
-     otp_err_e'(`FC_PATH.part_error[DaiIdx]) == AccessError
-    )
+		   part_has_digest && dai_write_req && dai_addr_below_digest |-> ##[2:4]
+		   dai_access_error)
 
   ////////////////////////////////////////////////////
   // fuse_ctrl zeroization


### PR DESCRIPTION
On behalf of @rswarbrick :

This assertion is checking that a partition will respond with an error to any DAI write once the partition has a digest.

Unfortunately, the timing wasn't quite right: if scrambling is enabled for the partition, the write mechanism in otp_ctrl_dai spends two extra cycles computing the scrambled address and data before it tries to write the value and spots that the partition is locked.

Modelling the exact timing carefully is a bit fiddly (because you can't do ##[my_variable] in SVA) so this cheats slightly by weakening the assertion. It thus says that if we expect an error it will come out in between 2 and 4 cycles (even though we could, in theory decide whether the value should be 2 or 4).

I've also tidied up the assertion a bit to make it easier to read: it took me a while to decipher, but we may as well make it easier for the next person.

-----------------------------------

As with https://github.com/chipsalliance/caliptra-ss/pull/740, this won't actually manage to run CI because I can't figure out how to push to chipsalliance/caliptra-ss. But I thought it might be worth showing the fix to avoid anyone in the Microsoft team (such as @ekarabu) spending time on the regression failure that it caused in the nightly randomised regression yesterday (caliptra_ss_fuse_ctrl_test_unlocked0_prov__4084803283).