### PR TITLE
[fuse_ctrl] Obfuscate zeroization result

### DIFF
--- a/src/fuse_ctrl/rtl/otp_ctrl_dai.sv
+++ b/src/fuse_ctrl/rtl/otp_ctrl_dai.sv
@@ -735,7 +735,7 @@ module otp_ctrl_dai
             state_d = IdleSt;
 
             if (otp_err == NoError) begin
-              // Unconditionally release the `countones` value of the zeroized word.
+              // Unconditionally return all-ones.
               data_en = 1'b1;
               // Flop trigger for the affected partition such that it can disable
               // periodic checks that could fail.
@@ -933,7 +933,7 @@ module otp_ctrl_dai
         end else if (data_sel == DaiData) begin
           data_q <= dai_wdata_i;
         end else if (data_sel == ZerData) begin
-          data_q <= countones(otp_rdata_i);
+          data_q <= {ScrmblBlockWidth{1'b1}};
         end else begin
           data_q <= otp_rdata_i;
         end

--- a/src/fuse_ctrl/rtl/otp_ctrl_dai.sv
+++ b/src/fuse_ctrl/rtl/otp_ctrl_dai.sv
@@ -149,7 +149,8 @@ module otp_ctrl_dai
   typedef enum logic [1:0] {
     OtpData = 2'b00,
     DaiData = 2'b01,
-    ScrmblData = 2'b10
+    ScrmblData = 2'b10,
+    ZerData = 2'b11
   } data_sel_e;
 
 
@@ -755,10 +756,11 @@ module otp_ctrl_dai
       ///////////////////////////////////////////////////////////////////
       // Wait for OTP response to the zeroization request. An error or
       // a non-zeroized value will not be returned to software. Note that
-      // in order to retry a failed zeroization requeset all errors are
+      // in order to retry a failed zeroization request all errors are
       // treated as recoverable.
       ZerWaitSt: begin
         dai_prog_idle_o = 1'b0;
+        data_sel = ZerData;
         // Continuously check write access and bail out if this is not consistent.
         if (PartInfo[part_idx].zeroizable &&
             // The entire address space of a zeroizable partition is writable.
@@ -975,6 +977,8 @@ module otp_ctrl_dai
           data_q <= scrmbl_data_i;
         end else if (data_sel == DaiData) begin
           data_q <= dai_wdata_i;
+        end else if (data_sel == ZerData) begin
+          data_q <= countones(otp_rdata_i);
         end else begin
           data_q <= otp_rdata_i;
         end

--- a/src/fuse_ctrl/rtl/otp_ctrl_dai.sv
+++ b/src/fuse_ctrl/rtl/otp_ctrl_dai.sv
@@ -196,42 +196,6 @@ module otp_ctrl_dai
   // after digest and write ops.
   assign dai_rdata_o   = (state_q == IdleSt) ? data_q : '0;
 
-  ///////////////////////
-  // Zeroization Check //
-  ///////////////////////
-
-  // The read-out data is is buffered and replicated, then screened for the
-  // zeroization marker. This is only relevant for the `ZEROIZE` command to
-  // prevent exposing scrambled data to software.
-
-  localparam int ZerFanout = 4;
-
-  // Compose several individual MuBis into a larger MuBi. The resulting
-  // value must always be a valid MuBi constant (either `true` or `false`).
-  logic   [ZerFanout-1:0][ScrmblBlockWidth-1:0] otp_rdata_post;
-  mubi4_t [ZerFanout-1:0] zeroized_valid_pre;
-  mubi16_t zeroized_valid;
-  for (genvar k = 0; k < ZerFanout; k++) begin
-    caliptra_prim_buf #(
-      .Width(ScrmblBlockWidth)
-    ) u_rdata_buf (
-      .in_i  ( otp_rdata_i       ),
-      .out_o ( otp_rdata_post[k] )
-    );
-
-    // Interleave MuBi4 chunks to create a higher-order MuBi.
-    // Even indices: (MuBi4True, MuBi4False)
-    // Odd indices:  (MuBi4False, MuBi4True)
-    assign zeroized_valid_pre[k] = (check_zeroized_valid(otp_rdata_post[k]) ^~ (k % 2 == 0)) ? MuBi4True : MuBi4False;
-  end
-
-  caliptra_prim_buf #(
-    .Width(MuBi16Width)
-  ) u_zeroized_valid_buf (
-    .in_i  ( zeroized_valid_pre ),
-    .out_o ( {zeroized_valid}   )
-  );
-
   always_comb begin : p_fsm
     state_d = state_q;
 
@@ -771,20 +735,11 @@ module otp_ctrl_dai
             state_d = IdleSt;
 
             if (otp_err == NoError) begin
-              if (PartInfo[part_idx].secret) begin
-                // Only release the zeroized fuse when the read out data reaches
-                // the valid threshold.
-                if (mubi16_test_true_strict(zeroized_valid)) begin
-                  data_en = 1'b1;
-                  // Flop trigger for the affected partition such that it can disable
-                  // periodic checks that could fail.
-                  zer_trigs_d[part_idx] = MuBi8True;
-                end
-              // For software partitions, the read out data is always released.
-              end else begin
-                data_en = 1'b1;
-              end
-
+              // Unconditionally release the `countones` value of the zeroized word.
+              data_en = 1'b1;
+              // Flop trigger for the affected partition such that it can disable
+              // periodic checks that could fail.
+              zer_trigs_d[part_idx] = MuBi8True;
             end else begin
               error_d = otp_err;
             end
@@ -829,7 +784,7 @@ module otp_ctrl_dai
     // Unconditionally jump into the terminal error state when a zeroization
     // indicator takes on an invalid value.
     for (int k = 0; k < NumPart; k++) begin
-      if (mubi8_test_invalid(zer_trigs_o[k]) || mubi16_test_invalid(zeroized_valid)) begin
+      if (mubi8_test_invalid(zer_trigs_o[k])) begin
         state_d = ErrorSt;
         fsm_err_o = 1'b1;
         error_d = FsmStateError;

--- a/src/fuse_ctrl/rtl/otp_ctrl_part_buf.sv
+++ b/src/fuse_ctrl/rtl/otp_ctrl_part_buf.sv
@@ -219,37 +219,54 @@ module otp_ctrl_part_buf
     end
   end
 
-  // Screen the read out data for the zeroization marker. This is only relevant
-  // to determine whether the partition is zeroized upon initialization.
+  ///////////////////////
+  // Zeroization Logic //
+  ///////////////////////
 
-  localparam int ZerFanout = 2;
-
-  // Compose several individual MuBis into a larger MuBi. The resulting
-  // value must always be a valid MuBi constant (either `true` or `false`).
-  logic   [ZerFanout-1:0][ScrmblBlockWidth-1:0] zer_mrk_post;
-  mubi4_t [ZerFanout-1:0] is_zeroized_pre;
   mubi8_t is_zeroized;
 
-  for (genvar k = 0; k < ZerFanout; k++) begin
+  if (Info.zeroizable) begin : gen_zeroizable_part
+    // Screen the read out data for the zeroization marker. This is only relevant
+    // to determine whether the partition is zeroized upon initialization.
+
+    localparam int ZerFanout = 2;
+
+    // Compose several individual MuBis into a larger MuBi. The resulting
+    // value must always be a valid MuBi constant (either `true` or `false`).
+    logic   [ZerFanout-1:0][ScrmblBlockWidth-1:0] zer_mrk_post;
+    logic   [ZerFanout-1:0][$clog2(ScrmblBlockWidth+1)-1:0] zer_mrk_cnt;
+    mubi4_t [ZerFanout-1:0] is_zeroized_pre;
+
+    for (genvar k = 0; k < ZerFanout; k++) begin
+      caliptra_prim_buf #(
+        .Width(ScrmblBlockWidth)
+      ) u_rdata_buf (
+        .in_i  ( zer_mrk         ),
+        .out_o ( zer_mrk_post[k] )
+      );
+
+      // Count the number of ones.
+      assign zer_mrk_cnt[k] = countones(zer_mrk_post[k]);
+
+      // Interleave MuBi4 chunks to create higher-order MuBis.
+      // Even indices: (MuBi4True, MuBi4False)
+      // Odd indices:  (MuBi4False, MuBi4True)
+      assign is_zeroized_pre[k] = (check_zeroized_valid(zer_mrk_cnt[k]) ^~ (k % 2 == 0)) ?
+                                  MuBi4True : MuBi4False;
+    end
+
     caliptra_prim_buf #(
-      .Width(ScrmblBlockWidth)
-    ) u_rdata_buf (
-      .in_i  ( zer_mrk         ),
-      .out_o ( zer_mrk_post[k] )
+      .Width(MuBi8Width)
+    ) u_is_zeroized_buf (
+      .in_i  ( is_zeroized_pre ),
+      .out_o ( {is_zeroized}   )
     );
 
-    // Interleave MuBi4 chunks to create higher-order MuBis.
-    // Even indices: (MuBi4True, MuBi4False)
-    // Odd indices:  (MuBi4False, MuBi4True)
-    assign is_zeroized_pre[k] = (check_zeroized_valid(zer_mrk_post[k]) ^~ (k % 2 == 0)) ? MuBi4True : MuBi4False;
+  end else begin : gen_not_zeroizable_part
+    logic unused_bits;
+    assign unused_bits = ^zer_mrk;
+    assign is_zeroized = MuBi8False;
   end
-
-  caliptra_prim_buf #(
-    .Width(MuBi8Width)
-  ) u_is_zeroized_buf (
-    .in_i  ( is_zeroized_pre ),
-    .out_o ( {is_zeroized}   )
-  );
 
   caliptra_prim_mubi8_sender #(
     .AsyncOn(0)

--- a/src/fuse_ctrl/rtl/otp_ctrl_part_unbuf.sv
+++ b/src/fuse_ctrl/rtl/otp_ctrl_part_unbuf.sv
@@ -172,37 +172,54 @@ module otp_ctrl_part_unbuf
     end
   end
 
-  // Screen the read out data for the zeroization marker. This is only relevant
-  // to determine whether the partition is zeroized upon initialization.
+  ///////////////////////
+  // Zeroization Logic //
+  ///////////////////////
 
-  localparam int ZerFanout = 2;
-
-  // Compose several individual MuBis into a larger MuBi. The resulting
-  // value must always be a valid MuBi constant (either `true` or `false`).
-  logic   [ZerFanout-1:0][ScrmblBlockWidth-1:0] zer_mrk_post;
-  mubi4_t [ZerFanout-1:0] is_zeroized_pre;
   mubi8_t is_zeroized;
 
-  for (genvar k = 0; k < ZerFanout; k++) begin
+  if (Info.zeroizable) begin : gen_zeroizable_part
+    // Screen the read out data for the zeroization marker. This is only relevant
+    // to determine whether the partition is zeroized upon initialization.
+
+    localparam int ZerFanout = 2;
+
+    // Compose several individual MuBis into a larger MuBi. The resulting
+    // value must always be a valid MuBi constant (either `true` or `false`).
+    logic   [ZerFanout-1:0][ScrmblBlockWidth-1:0] zer_mrk_post;
+    logic   [ZerFanout-1:0][$clog2(ScrmblBlockWidth+1)-1:0] zer_mrk_cnt;
+    mubi4_t [ZerFanout-1:0] is_zeroized_pre;
+
+    for (genvar k = 0; k < ZerFanout; k++) begin
+      caliptra_prim_buf #(
+        .Width(ScrmblBlockWidth)
+      ) u_rdata_buf (
+        .in_i  ( zer_mrk         ),
+        .out_o ( zer_mrk_post[k] )
+      );
+
+      // Count the number of ones.
+      assign zer_mrk_cnt[k] = countones(zer_mrk_post[k]);
+
+      // Interleave MuBi4 chunks to create higher-order MuBis.
+      // Even indices: (MuBi4True, MuBi4False)
+      // Odd indices:  (MuBi4False, MuBi4True)
+      assign is_zeroized_pre[k] = (check_zeroized_valid(zer_mrk_cnt[k]) ^~ (k % 2 == 0)) ?
+                                  MuBi4True : MuBi4False;
+    end
+
     caliptra_prim_buf #(
-      .Width(ScrmblBlockWidth)
-    ) u_rdata_buf (
-      .in_i  ( zer_mrk         ),
-      .out_o ( zer_mrk_post[k] )
+      .Width(MuBi8Width)
+    ) u_is_zeroized_buf (
+      .in_i  ( is_zeroized_pre ),
+      .out_o ( {is_zeroized}   )
     );
 
-    // Interleave MuBi4 chunks to create higher-order MuBis.
-    // Even indices: (MuBi4True, MuBi4False)
-    // Odd indices:  (MuBi4False, MuBi4True)
-    assign is_zeroized_pre[k] = (check_zeroized_valid(zer_mrk_post[k]) ^~ (k % 2 == 0)) ? MuBi4True : MuBi4False;
+  end else begin : gen_not_zeroizable_part
+    logic unused_bits;
+    assign unused_bits = ^zer_mrk;
+    assign is_zeroized = MuBi8False;
   end
-
-  caliptra_prim_buf #(
-    .Width(MuBi8Width)
-  ) u_is_zeroized_buf (
-    .in_i  ( is_zeroized_pre ),
-    .out_o ( {is_zeroized}   )
-  );
 
   caliptra_prim_mubi8_sender #(
     .AsyncOn(0)

--- a/src/fuse_ctrl/rtl/otp_ctrl_pkg.sv
+++ b/src/fuse_ctrl/rtl/otp_ctrl_pkg.sv
@@ -110,9 +110,19 @@ package otp_ctrl_pkg;
   // stuck-at-0 bits.
   parameter int unsigned ZeroizationValidBound = ScrmblBlockWidth - 6; // 90.625%
 
-  // Check if the zeroization marker falls into the valid range.
+  // Count the number of set bits in a word. Effectively implements `$countones` which is not
+  // supported by all tools.
+  function automatic logic [ScrmblBlockWidth-1:0] countones(logic [ScrmblBlockWidth-1:0] word);
+    logic [ScrmblBlockWidth-1:0] count = '0;
+    for (int i = 0; i < ScrmblBlockWidth; i++) begin
+      count = count + word[i];
+    end
+    return count;
+  endfunction : countones
+
+  // Check if the zeroization marker fulfills the zeroization criterion.
   function automatic logic check_zeroized_valid(logic [ScrmblBlockWidth-1:0] word);
-    return $countones(word) >= ZeroizationValidBound;
+    return countones(word) >= ZeroizationValidBound;
   endfunction : check_zeroized_valid
 
   ///////////////////////////////

--- a/src/fuse_ctrl/rtl/otp_ctrl_pkg.sv
+++ b/src/fuse_ctrl/rtl/otp_ctrl_pkg.sv
@@ -121,8 +121,8 @@ package otp_ctrl_pkg;
   endfunction : countones
 
   // Check if the zeroization marker fulfills the zeroization criterion.
-  function automatic logic check_zeroized_valid(logic [ScrmblBlockWidth-1:0] word);
-    return countones(word) >= ZeroizationValidBound;
+  function automatic logic check_zeroized_valid(logic [$clog2(ScrmblBlockWidth+1)-1:0] count);
+    return count >= ZeroizationValidBound;
   endfunction : check_zeroized_valid
 
   ///////////////////////////////


### PR DESCRIPTION
This PR modifies the behavior of the DAI Zeroize command to no longer return the scrambled word after zeroization but instead just all-1s (independent of the actual fuse values). This is to not give away any potential information of the zeroized values.