### PR TITLE
Add define to get FSMs recognized as such

### DIFF
--- a/src/integration/config/compile.yml
+++ b/src/integration/config/compile.yml
@@ -230,6 +230,7 @@ global:
         #FIXME : remve this Note suppression
         - '-suppress=SV-LCM-PPWI'
         - +define+I3C_BOOT_USING_ENTDAA
+        - +define+CALIPTRA_SIMULATION
       elab:
         #FIXME : remve this warning suppression
         #FIXME implicit-wire-no-fanin and port-connection-width-mismatch warnings from i3c_core


### PR DESCRIPTION
This is work from @martin-velay to get coverage reports to recognise FSMs and is required in order to get decent coverage analysis results.

Unfortunately, it fails a CI check that tests that `compile.yml` is unchanged. Not surprising: it isn't! But I'm not sure how to get progress here. @ekarabu: Do you know what needs doing to allow this to work?

(Originally posted as part of #806, but pulled out because it was causing CI to fail)