### PR TITLE
[DOC] Revise cptra_ss_clk_i frequency and clarify MCI DMI access

### DIFF
--- a/docs/CaliptraSSHardwareSpecification.md
+++ b/docs/CaliptraSSHardwareSpecification.md
@@ -1321,10 +1321,10 @@ The MCI DMI Interface gives select access to the blocks inside MCI.
 
 Access to MCI's DMI space (MCU Uncore) is split into two different levels of security:
 
-| **Access** 	| **Description** 	| 
-| :--------- 	| :--------- 	| 
-| **Debug Intent/Manufacture Mode**|  Always accessable over DMI whenever [MCU uncore DMI enabled](#mcu-dmi-enable-control).| 
-| **Debug Unlock**|  Accessable over DMI only if LCC is Debug Unlocked| 
+| **Access** 	| **Description** 	|
+| :--------- 	| :--------- 	|
+| **Debug Locked**|  Registers and memories behind this security level are always accessible over DMI whenever [MCU uncore DMI enabled](#mcu-dmi-enable-control).|
+| **Debug Unlock**|  Registers and memories behind this security level are only accessible over DMI when LCC is Debug Unlocked.|
 
 Illegal accesses will result in writes being dropped and reads returning 0.
 
@@ -1332,53 +1332,53 @@ Illegal accesses will result in writes being dropped and reads returning 0.
 
 ##### MCI DMI Memory Map
 
-| Register Name | DMI Address | Access Type | Debug Intent Access | Manufacture Mode Access | Debug Unlock Access |
-| :---- | :---- | :---- | :---- | :---- | :---- |
-| **NOT ENABLED IN 2.0** MBOX0\_DLEN | 0x50 | RO | Yes |  |  |
-| **NOT ENABLED IN 2.0** MBOX0\_DOUT | 0x51 | RO | Yes |  |  |
-| **NOT ENABLED IN 2.0** MBOX0\_STATUS | 0x52 | RO | Yes |  |  |
-| **NOT ENABLED IN 2.0** MBOX0\_DIN | 0x53 | WO | Yes |  |  |
-| **NOT ENABLED IN 2.0** MBOX1\_DLEN | 0x54 | RO | Yes |  |  |
-| **NOT ENABLED IN 2.0** MBOX1\_DOUT | 0x55 | RO | Yes |  |  |
-| **NOT ENABLED IN 2.0** MBOX1\_STATUS | 0x56 | RO | Yes |  |  |
-| **NOT ENABLED IN 2.0** MBOX1\_DIN | 0x57 | WO | Yes |  |  |
-| MCU\_SRAM\_ADDR | 0x58 | RW |  |  | Yes |
-| MCU\_SRAM\_DATA | 0x59 | RW |  |  | Yes |
-| MCU\_TRACE\_STATUS | 0x5A | RO |  |  | Yes |
-| MCU\_TRACE\_CONFIG | 0x5B | RO |  |  | Yes |
-| MCU\_TRACE\_WR\_PTR | 0x5C | RO |  |  | Yes |
-| MCU\_TRACE\_RD\_PTR | 0x5D | RW |  |  | Yes |
-| MCU\_TRACE\_DATA | 0x5E | RO |  |  | Yes |
-| HW\_FLOW\_STATUS | 0x5F | RO | Yes |  |  |
-| RESET\_REASON | 0x60 | RO | Yes |  |  |
-| RESET\_STATUS | 0x61 | RO | Yes |  |  |
-| FW\_FLOW\_STATUS | 0x62 | RO | Yes |  |  |
-| HW\_ERROR\_FATAL | 0x63 | RO | Yes |  |  |
-| AGG\_ERROR\_FATAL | 0x64 | RO | Yes |  |  |
-| HW\_ERROR\_NON\_FATAL | 0x65 | RO | Yes |  |  |
-| AGG\_ERROR\_NON\_FATAL | 0x66 | RO | Yes |  |  |
-| FW\_ERROR\_FATAL | 0x67 | RO | Yes |  |  |
-| FW\_ERROR\_NON\_FATAL | 0x68 | RO | Yes |  |  |
-| HW\_ERROR\_ENC | 0x69 | RO | Yes |  |  |
-| FW\_ERROR\_ENC | 0x6A | RO | Yes |  |  |
-| FW\_EXTENDED\_ERROR\_INFO\_0 | 0x6B | RO | Yes |  |  |
-| FW\_EXTENDED\_ERROR\_INFO\_1 | 0x6C | RO | Yes |  |  |
-| FW\_EXTENDED\_ERROR\_INFO\_2 | 0x6D | RO | Yes |  |  |
-| FW\_EXTENDED\_ERROR\_INFO\_3 | 0x6E | RO | Yes |  |  |
-| FW\_EXTENDED\_ERROR\_INFO\_4 | 0x6F | RO | Yes |  |  |
-| FW\_EXTENDED\_ERROR\_INFO\_5 | 0x70 | RO | Yes |  |  |
-| FW\_EXTENDED\_ERROR\_INFO\_6 | 0x71 | RO | Yes |  |  |
-| FW\_EXTENDED\_ERROR\_INFO\_7 | 0x72 | RO | Yes |  |  |
-| RESET\_REQUEST | 0x73 | RW |  |  | Yes |
-| MCI\_BOOTFSM\_GO | 0x74 | RW | Yes |  |  |
-| CPTRA\_BOOT\_GO | 0x75 | RW |  |  | Yes |
-| FW\_SRAM\_EXEC\_REGION\_SIZE | 0x76 | RW |  |  | Yes |
-| MCU\_RESET\_VECTOR | 0x77 | RW |  |  | Yes |
-| SS\_DEBUG\_INTENT | 0x78 | RW |  |  | Yes |
-| SS\_CONFIG\_DONE | 0x79 | RW |  |  | Yes |
-| SS\_CONFIG\_DONE\_STICKY | 0x7A | RW |  |  | Yes |
-| MCU\_NMI\_VECTOR | 0x7B | RW |  |  | Yes |
-| MCI\_DMI\_MCI\_HW\_OVERRIDE ([DMI ONLY Reg](#dmi-only-registers)) | 0x7C | RW |  |  | Yes |
+| Register Name | DMI Address | Access Type | Debug Locked Access | Debug Unlock Access |
+| :---- | :---- | :---- | :---- | :---- |
+| **NOT ENABLED IN 2.0** MBOX0\_DLEN | 0x50 | RO | Yes |  |
+| **NOT ENABLED IN 2.0** MBOX0\_DOUT | 0x51 | RO | Yes |  |
+| **NOT ENABLED IN 2.0** MBOX0\_STATUS | 0x52 | RO | Yes |  |
+| **NOT ENABLED IN 2.0** MBOX0\_DIN | 0x53 | WO | Yes |  |
+| **NOT ENABLED IN 2.0** MBOX1\_DLEN | 0x54 | RO | Yes |  |
+| **NOT ENABLED IN 2.0** MBOX1\_DOUT | 0x55 | RO | Yes |  |
+| **NOT ENABLED IN 2.0** MBOX1\_STATUS | 0x56 | RO | Yes |  |
+| **NOT ENABLED IN 2.0** MBOX1\_DIN | 0x57 | WO | Yes |  |
+| MCU\_SRAM\_ADDR | 0x58 | RW |  | Yes |
+| MCU\_SRAM\_DATA | 0x59 | RW |  | Yes |
+| MCU\_TRACE\_STATUS | 0x5A | RO |  | Yes |
+| MCU\_TRACE\_CONFIG | 0x5B | RO |  | Yes |
+| MCU\_TRACE\_WR\_PTR | 0x5C | RO |  | Yes |
+| MCU\_TRACE\_RD\_PTR | 0x5D | RW |  | Yes |
+| MCU\_TRACE\_DATA | 0x5E | RO |  | Yes |
+| HW\_FLOW\_STATUS | 0x5F | RO | Yes |  |
+| RESET\_REASON | 0x60 | RO | Yes |  |
+| RESET\_STATUS | 0x61 | RO | Yes |  |
+| FW\_FLOW\_STATUS | 0x62 | RO | Yes |  |
+| HW\_ERROR\_FATAL | 0x63 | RO | Yes |  |
+| AGG\_ERROR\_FATAL | 0x64 | RO | Yes |  |
+| HW\_ERROR\_NON\_FATAL | 0x65 | RO | Yes |  |
+| AGG\_ERROR\_NON\_FATAL | 0x66 | RO | Yes |  |
+| FW\_ERROR\_FATAL | 0x67 | RO | Yes |  |
+| FW\_ERROR\_NON\_FATAL | 0x68 | RO | Yes |  |
+| HW\_ERROR\_ENC | 0x69 | RO | Yes |  |
+| FW\_ERROR\_ENC | 0x6A | RO | Yes |  |
+| FW\_EXTENDED\_ERROR\_INFO\_0 | 0x6B | RO | Yes |  |
+| FW\_EXTENDED\_ERROR\_INFO\_1 | 0x6C | RO | Yes |  |
+| FW\_EXTENDED\_ERROR\_INFO\_2 | 0x6D | RO | Yes |  |
+| FW\_EXTENDED\_ERROR\_INFO\_3 | 0x6E | RO | Yes |  |
+| FW\_EXTENDED\_ERROR\_INFO\_4 | 0x6F | RO | Yes |  |
+| FW\_EXTENDED\_ERROR\_INFO\_5 | 0x70 | RO | Yes |  |
+| FW\_EXTENDED\_ERROR\_INFO\_6 | 0x71 | RO | Yes |  |
+| FW\_EXTENDED\_ERROR\_INFO\_7 | 0x72 | RO | Yes |  |
+| RESET\_REQUEST | 0x73 | RW |  | Yes |
+| MCI\_BOOTFSM\_GO | 0x74 | RW | Yes |  |
+| CPTRA\_BOOT\_GO | 0x75 | RW |  | Yes |
+| FW\_SRAM\_EXEC\_REGION\_SIZE | 0x76 | RW |  | Yes |
+| MCU\_RESET\_VECTOR | 0x77 | RW |  | Yes |
+| SS\_DEBUG\_INTENT | 0x78 | RW |  | Yes |
+| SS\_CONFIG\_DONE | 0x79 | RW |  | Yes |
+| SS\_CONFIG\_DONE\_STICKY | 0x7A | RW |  | Yes |
+| MCU\_NMI\_VECTOR | 0x7B | RW |  | Yes |
+| MCI\_DMI\_MCI\_HW\_OVERRIDE ([DMI ONLY Reg](#dmi-only-registers)) | 0x7C | RW |  | Yes |
 
 ###### DMI Only Registers 
 

--- a/docs/CaliptraSSIntegrationSpecification.md
+++ b/docs/CaliptraSSIntegrationSpecification.md
@@ -479,8 +479,12 @@ File at this path in the repository includes parameters and defines for Caliptra
 The `cptra_ss_clk_i` signal is the primary clock input for the Caliptra Subsystem.
 
   - **Signal Name** `cptra_ss_clk_i`
-  - **Required Frequency** 170 Mhz to 400 MHz
-    - I3C core imposes requirement for minimum operating clock frequency set to 170 Mhz or higher.
+  - **Required Frequency** 333* MHz to 400 MHz
+    - I3C core imposes requirement for minimum operating clock frequency set to 333 MHz or higher to meet 12ns tSCO timing.
+    - SoCs that run Caliptra lower than 333 MHz will limit the max I3C SCL frequency. See [I3C Phy Spec](https://chipsalliance.github.io/i3c-core/phy.html#clock-synchronization-5-1-7) for more details.
+    - This was changed from 170 MHz floor due to CDC issue found in I3C core:
+       - [I3C Repo CDC Issue](https://github.com/chipsalliance/i3c-core/issues/72)
+       - [Caliptra-SS Repo I3C CDC Issue](https://github.com/chipsalliance/caliptra-ss/issues/777) 
   - **Clock Source** Must be derived from the SoC’s clock generation module or a stable external oscillator.
   - **Integration Notes**
      1. Verify that the SoC or system-level clock source provides a stable clock.


### PR DESCRIPTION
- Cherry-pick into 2.0 branch https://github.com/chipsalliance/caliptra-ss/pull/941
   - Updated required frequency for cptra_ss_clk_i signal to 333 MHz and added note on I3C SCL frequency limitations.
   - Clarify MCI DMI access for debug unlock vs debug locked
