### PR TITLE
[DOC] Update I3C core integration details

### DIFF
--- a/docs/CaliptraSSIntegrationSpecification.md
+++ b/docs/CaliptraSSIntegrationSpecification.md
@@ -2342,7 +2342,6 @@ The I3C core can be configured as an [AXI Recovery interface](CaliptraSSHardware
   - Connection to AXI interface
   - GPIO connection to I3C Host (VIP or RTL)
 
-
 ## Parameters and defines
 
 | Parameter/Define   | Default Value                         | Description                                 |


### PR DESCRIPTION
Clarified I3C cannot be used as both AXI RI and I3C. It can be one or the other.