### PR TITLE
changes to enable dvsim tool to run

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+{
+  description = "caliptra-ss Nix Packages and Environments";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
+    flake-utils.url = "github:numtide/flake-utils";
+
+    ##########
+    # PYTHON #
+    ##########
+
+    pyproject-nix = {
+      url = "github:pyproject-nix/pyproject.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    pyproject-build-systems = {
+      url = "github:pyproject-nix/build-system-pkgs";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.pyproject-nix.follows = "pyproject-nix";
+      inputs.uv2nix.follows = "uv2nix";
+    };
+    uv2nix = {
+      url = "github:pyproject-nix/uv2nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.pyproject-nix.follows = "pyproject-nix";
+    };
+  };
+
+  outputs = inputs: let
+    all_system_outputs = inputs.flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = import inputs.nixpkgs {
+        inherit system;
+      };
+      python_dvsim = pkgs.callPackage ./tools/dvsim/python {inherit inputs;};
+      python_reg_gen = pkgs.callPackage ./tools/scripts/python {inherit inputs;};
+
+      # Environment variables derivable from the repo layout.
+      # Variables that cannot be auto-set here:
+      #   CALIPTRA_WORKSPACE — user-specific parent dir for verilator scratch output
+      #   RV_ROOT            — external VeeR-EL2 checkout (not a submodule)
+      commonShellHook = ''
+        export CALIPTRA_ROOT="$(git rev-parse --show-toplevel)"
+        export ADAMSBRIDGE_ROOT="$CALIPTRA_ROOT/submodules/adams-bridge"
+      '';
+      dvsimShellHook = commonShellHook + ''
+        # EDA simulators (e.g. Cadence's xrun) invoke a vendor-bundled gcc to compile C DPI
+        # sources, and do not reliably pick up openssl from the environment's standard
+        # compiler search paths. Export fixed env vars pointing at the openssl headers and
+        # libraries provided by this devshell so dvsim hjson can thread them to the
+        # simulator's C compiler as explicit -I/-L flags, making the build reproducible
+        # across host distros.
+        export OPENSSL_INCLUDE_DIR="${pkgs.openssl.dev}/include"
+        export OPENSSL_LIB_DIR="${pkgs.openssl.out}/lib"
+        # Vendor EDA binaries (e.g. Verdi's libnovas.so loaded by simv) are foreign ELFs
+        # that dlopen shared libs via the loader's default search path. mkShell does not
+        # populate LD_LIBRARY_PATH for runtime, so expose the libs they DT_NEED here.
+        export LD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath [
+          pkgs.zlib
+          pkgs.numactl
+          pkgs.ncurses
+          pkgs.stdenv.cc.cc.lib
+        ]}''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+      '';
+    in {
+      devShells = rec {
+        default = caliptra-dvsim;
+        caliptra-dvsim = pkgs.mkShell {
+          name = "caliptra-dvsim";
+          packages = ([
+            python_dvsim
+          ]) ++ (with pkgs; [
+            uv
+            # Needed by the AES DPI model's crypto.c (openssl/conf.h etc.); xrun also links -lcrypto.
+            openssl
+            openssl.dev
+          ]);
+          shellHook = dvsimShellHook;
+        };
+        caliptra-reg-gen = pkgs.mkShell {
+          name = "caliptra-reg-gen";
+          packages = [
+            python_reg_gen
+          ];
+          shellHook = commonShellHook;
+        };
+      };
+    });
+  in
+    all_system_outputs;
+}

--- a/tools/dvsim/common_modes.hjson
+++ b/tools/dvsim/common_modes.hjson
@@ -1,0 +1,82 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  // Sim modes are collection of build_opts and run_opts
+  // These are only set on the command line
+  // These are different from the build modes in the sense that these collection of
+  // options are appended to actual build_modes
+  build_modes: [
+    {
+      name: gui
+      is_sim_mode: 1
+      en_build_modes: ["{tool}_gui"]
+    }
+    {
+      name: gui_debug
+      is_sim_mode: 1
+      en_build_modes: ["{tool}_gui_debug"]
+    }
+    {
+      name: waves
+      is_sim_mode: 1
+      en_build_modes: ["{tool}_waves"]
+    }
+    {
+      name: waves_off
+      is_sim_mode: 1
+      en_build_modes: ["{tool}_waves_off"]
+    }
+    {
+      name: cov
+      is_sim_mode: 1
+      en_build_modes: ["{tool}_cov"]
+      // This plusarg is retrieved in `hw/dv/sv/dv_lib/dv_base_test.sv`. If not set, the coverage
+      // collection components are not created.
+      run_opts: ["+en_cov=1"]
+    }
+    {
+      name: profile
+      is_sim_mode: 1
+      en_build_modes: ["{tool}_profile"]
+    }
+    {
+      name: xprop
+      is_sim_mode: 1
+      en_build_modes: ["{tool}_xprop"]
+    }
+    {
+      name: loopdetect
+      is_sim_mode: 1
+      en_build_modes: ["{tool}_loopdetect"]
+    }
+    // Enables randomization of testbench / RTL build.
+    //
+    // Build randomization is achieved by passing `--build-seed <optional-seed>` on the dvsim
+    // command-line. If not passed, the build is not randomized. Build randomization is achieved
+    // in two ways. One of them is setting the pre-processor macro `BUILD_SEED` to the seed value,
+    // which is done below. The SystemVerilog testbench sources can use the `BUILD_SEED` macro
+    // value to set some design constants (such as parameters) upon instantiation. The `BUILD_SEED`,
+    // if not set externally (by passing the --build-seed switch) is set to 1 in
+    // `hw/dv/sv/dv_utils/dv_macros.svh`. The other way is by passing the {seed} value to utility
+    // scripts that generate packages that contain randomized constants. These utility scripts can
+    // be invoked as a `pre_build_cmd`, wrapped within the `build_seed` sim mode in the DUT
+    // simulation configuration Hjson file. All forms of build randomization must be wrapped within
+    // this `build_seed` sim mode. They will all use the same {seed} value, which allows us to
+    // deterministically reproduce failures. The `--build-seed` switch is expected to be passed
+    // when running the nightly regressions. The `seed` value set by dvsim is a 32-bit unsigned
+    // integer (unless specified on the command-line).
+    {
+      name: build_seed
+      is_sim_mode: 1
+      build_opts: ["+define+BUILD_SEED={seed}"]
+    }
+  ]
+
+  run_modes: [
+    {
+      name: uvm_trace
+      run_opts: ["+UVM_PHASE_TRACE", "+UVM_CONFIG_DB_TRACE", "+UVM_OBJECTION_TRACE"]
+    }
+  ]
+}

--- a/tools/dvsim/common_project_cfg.hjson
+++ b/tools/dvsim/common_project_cfg.hjson
@@ -1,0 +1,34 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  project:          ""
+  repo_server:      ""
+  book:             ""
+  doc_server:       ""
+  results_server:   ""
+
+  // Default directory structure for the output
+  scratch_base_path:  "{scratch_root}/{branch}"
+  scratch_path:       "{scratch_base_path}/{dut}-{flow}-{tool}"
+
+  // Common data structure
+  build_pass_patterns: []
+  // TODO: Add back FuseSoC fail pattern after
+  // https://github.com/lowRISC/opentitan/issues/7348 is resolved.
+  build_fail_patterns: []
+
+  exports: [
+    { SCRATCH_PATH: "{scratch_path}" },
+    { proj_root: "{proj_root}" }
+  ]
+
+  // Results server stuff - indicate what command to use to copy over the results.
+  // Workaround for gsutil to fall back to using python2.7.
+  results_server_prefix:      ""
+  results_server_cmd:         ""
+  results_html_name:          ""
+
+  // If defined, this is printed into the results md files
+  revision: ""
+}

--- a/tools/dvsim/common_sim_cfg.hjson
+++ b/tools/dvsim/common_sim_cfg.hjson
@@ -1,0 +1,168 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  flow:             sim
+  flow_makefile:    "{dv_root}/sim.mk"
+
+  // Where to find common DV code
+  dv_root:          "{proj_root}/tools/dvsim"
+  import_cfgs:      ["{dv_root}/common_project_cfg.hjson",
+                     "{dv_root}/common_modes.hjson",
+                     "{dv_root}/fusesoc.hjson",
+                     "{dv_root}/{tool}.hjson"]
+
+  sv_flist_gen_flags: []
+
+  // Default directory structure for the output
+  build_dir:          "{scratch_path}/{build_mode}"
+  run_dir_name:       "{index}.{test}"
+  run_dir:            "{scratch_path}/{run_dir_name}/latest"
+
+  // Default file to store build_seed value
+  build_seed_file_path: "{build_dir}/build_seed.log"
+
+  run_pass_patterns:   ["^TEST PASSED (UVM_)?CHECKS$"]
+  run_fail_patterns:   ["^UVM_ERROR\\s[^:].*$",
+                        "^UVM_FATAL\\s[^:].*$",
+                        "^UVM_WARNING\\s[^:].*$",
+                        "^Assert failed: ",
+                        "^\\s*Offending '.*'",
+                        "^TEST FAILED (UVM_)?CHECKS$",
+                        "^Error:.*$"]  // ISS errors
+
+  // Default UVM verbosity settings
+  expand_uvm_verbosity_n: UVM_NONE
+  expand_uvm_verbosity_l: UVM_LOW
+  expand_uvm_verbosity_m: UVM_MEDIUM
+  expand_uvm_verbosity_h: UVM_HIGH
+  expand_uvm_verbosity_f: UVM_FULL
+  expand_uvm_verbosity_d: UVM_DEBUG
+
+  // Default simulation verbosity (l => UVM_LOW). Can be overridden by
+  // the --verbosity command-line argument.
+  verbosity: l
+
+  // Path to the dut instance (this is used in a couple of places such as coverage cfg
+  // file, xprop cfg file etc. If this is different for your block, then override it with
+  // the 'overrides' directive.
+  dut_instance: "{tb}.dut"
+
+  timescale: "1ns/1ps"
+
+  // Top level simulation entities.
+  sim_tops: ["{tb}"]
+
+  // Default build and run opts
+  build_opts: [// Standard UVM defines
+               "+define+UVM",
+               "+define+UVM_NO_DEPRECATED",
+               "+define+UVM_REGEX_NO_DPI",
+               "+define+UVM_REG_ADDR_WIDTH=32",
+               "+define+UVM_REG_DATA_WIDTH=32",
+               "+define+UVM_REG_BYTENABLE_WIDTH=4",
+               "+define+SIMULATION",
+               "+define+DUT_HIER={dut_instance}"]
+
+  run_opts: ["+UVM_NO_RELNOTES",
+             "+UVM_VERBOSITY={expand_uvm_verbosity_{verbosity}}"]
+
+  sw_build_cmd: []
+
+  // Default list of things to export to shell
+  exports: [
+    { dv_root: "{dv_root}" },
+    { self_dir: "{self_dir}" },
+    { SIMULATOR: "{tool}" },
+    { GUI: "{gui}"},
+    { GUI_DEBUG: "{gui_debug}"},
+    { WAVES: "{waves}" },
+    { DUT_TOP: "{dut}" },
+    { TB_TOP: "{tb}" },
+    { dut_instance: "{dut_instance}" }
+  ]
+
+  // This is a placeholder for a variable that dvsim expects will exist. In OpenTitan, it points at
+  // a Python script that builds SW collateral for a simulation.
+  sw_build_cmd: ["true"]
+
+  // Build modes are collection of build_opts and run_opts
+  //
+  // To define a build mode that overrides these flags, add something
+  // like the following to the IP block's configuration:
+  //
+  //   build_modes: [
+  //     {
+  //       name: foo
+  //       build_opts: ["+define+bx",
+  //                    "+define+by",
+  //                    "+define+bz"]
+  //       run_opts: ["+rx=1",
+  //                  "+ry=2",
+  //                  "+rz=3"]
+  //     }
+  //   ]
+  //
+  // To use a build mode for a specific test, set the 'build_mode' key.
+  //
+  build_modes: []
+
+  // Regressions are tests that can be grouped together and run in one shot
+  // By default, two regressions are made available - "all" and "nightly". Both
+  // run all available tests for the DUT. "nightly" enables coverage as well.
+  // The 'tests' key is set to an empty list, which indicates "run everything".
+  // Regressions can enable sim modes, which are a set of build_opts and run_opts
+  // that are grouped together. These are appended to the build modes used by the
+  // tests.
+  regressions: [
+    {
+      name: smoke
+      tests: []
+      reseed: 1
+      run_opts: [
+        // Knob used to configure an existing test / vseq to have a shorter runtime.
+        "+smoke_test=1"
+      ]
+    }
+    {
+      name: all
+    }
+    {
+      name: all_once
+      reseed: 1
+    }
+    {
+      name: nightly
+      en_sim_modes: ["cov"]
+    }
+  ]
+
+  /////////
+  // VCS //
+  /////////
+
+  // Project defaults for VCS
+  vcs_cov_cfg_file: "{{build_mode}_vcs_cov_cfg_file}"
+  vcs_unr_cfg_file: "{dv_root}/tools/vcs/unr.cfg"
+  vcs_xprop_cfg_file: "{dv_root}/tools/vcs/xprop.cfg"
+  vcs_fsm_reset_cov_cfg_file: "{dv_root}/tools/vcs/fsm_reset_cov.cfg"
+  vcs_cov_excl_files: []
+
+  // Build-specific coverage cfg files for VCS.
+  default_vcs_cov_cfg_file: "-cm_hier {dv_root}/tools/vcs/cover.cfg+{dv_root}/tools/vcs/common_cov_excl.cfg"
+  cover_reg_top_vcs_cov_cfg_file: "-cm_hier {dv_root}/tools/vcs/cover_reg_top.cfg+{dv_root}/tools/vcs/common_cov_excl.cfg"
+
+  /////////////
+  // XCELIUM //
+  /////////////
+
+  // Project defaults for Xcelium
+  xcelium_cov_cfg_file: "{{build_mode}_xcelium_cov_cfg_file}"
+  xcelium_unr_cfg_file:  "{dv_root}/tools/xcelium/unr.cfg"
+  xcelium_cov_excl_script: "{dv_root}/tools/xcelium/common_cov_excl.tcl"
+  xcelium_cov_refine_files: []
+
+  // Build-specific coverage cfg files for Xcelium.
+  default_xcelium_cov_cfg_file: "{dv_root}/tools/xcelium/cover.ccf"
+  cover_reg_top_xcelium_cov_cfg_file: "{dv_root}/tools/xcelium/cover_reg_top.ccf"
+}

--- a/tools/dvsim/fusesoc.hjson
+++ b/tools/dvsim/fusesoc.hjson
@@ -1,0 +1,36 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  pre_build_cmds: [
+    // Generate fusesoc .core files from the Caliptra compile.yaml files into a
+    // temporary directory in the build dir. This is then passed via --cores-root
+    // to allow cores there to be discovered and resolved by fusesoc.
+    "cd {proj_root} && compile-to-core src {scratch_path}/cores && compile-to-core third_party/caliptra-rtl {scratch_path}/cores",
+
+    // Generate the UVM RAL files
+    "true",
+  ]
+
+  sv_flist_gen_dir: "{build_dir}/fusesoc-work"
+
+  sv_flist_gen_cmd: "fusesoc"
+  sv_flist_gen_opts: [
+    "--cores-root={scratch_path}/cores",
+    "--cores-root={proj_root}/src",
+    "--cores-root={proj_root}/tools/dv-classes",
+    "run",
+    "{sv_flist_gen_flags}",
+    "--target=sim",
+    "--work-root={sv_flist_gen_dir}",
+    "--setup",
+    "{fusesoc_core}",
+  ]
+
+  // Construct the expected path the the .f/.scr filelist that is passed to the
+  // simulator. Note. that fusesoc converts the colons ':' that make up the VLNV
+  // core identifier to underscores in the generated filename, so we need to copy
+  // that operation here to correctly form the path.
+  fusesoc_core_:      "{eval_cmd} echo \"{fusesoc_core}\" | tr ':' '_'"
+  sv_flist:           "{sv_flist_gen_dir}/{fusesoc_core_}.scr"
+}

--- a/tools/dvsim/python/default.nix
+++ b/tools/dvsim/python/default.nix
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+{
+  inputs,
+  pkgs,
+  python313,
+  lib,
+  ...
+}: let
+  mkEnv = python: let
+    workspace = inputs.uv2nix.lib.workspace.loadWorkspace {
+      workspaceRoot = ./.;
+    };
+    overlay = workspace.mkPyprojectOverlay {
+      sourcePreference = "wheel";
+    };
+
+    pythonSet =
+      (pkgs.callPackage inputs.pyproject-nix.build.packages {
+        inherit python;
+      })
+          .overrideScope
+      (
+        lib.composeManyExtensions [
+          inputs.pyproject-build-systems.overlays.default
+          overlay
+          # Wheel-first (see sourcePreference above): only first-party
+          # source-only deps need an override. compile-to-core has no wheel, so
+          # it builds from sdist and must declare its PEP 517 backend.
+          (final: prev: {
+            compile-to-core = prev.compile-to-core.overrideAttrs (old: {
+              nativeBuildInputs = old.nativeBuildInputs ++ (final.resolveBuildSystem {hatchling = [];});
+            });
+          })
+        ]
+      );
+
+    env = pythonSet.mkVirtualEnv "caliptra-dvsim" workspace.deps.default;
+  in
+    env;
+in
+  mkEnv python313

--- a/tools/dvsim/python/pyproject.toml
+++ b/tools/dvsim/python/pyproject.toml
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+[project]
+name = "caliptra-dvsim"
+version = "0.0.0"
+description = "Open-source hardware root-of-trust"
+requires-python = ">=3.13, <3.14"
+
+dependencies = [
+  # Linters
+  "flake8 ~= 7.1",
+  "isort ~= 5.10",
+  "mypy == 0.991",
+  "yapf==0.32.0",
+  "ruff>=0.9.6",
+
+  # The hardware package manager and build system.
+  "fusesoc==2.4.5",
+
+  # Build and run tool for Design Verification flows
+  "dvsim==1.49.9",
+
+  # Extract fusesoc information from compile.yaml files
+  "compile-to-core",
+]
+
+[tool.uv]
+# This is not a distributable package — pyproject.toml is used only for dependency management.
+package = false
+
+[tool.uv.sources]
+compile-to-core = { git = "https://github.com/lowRISC/compile-to-core", branch = "main" }
+
+[tool.setuptools]
+py-modules = []
+
+[tool.ruff]
+target-version = "py310"
+line-length = 100
+# Don't lint vendored files which must be fixed upstream.
+extend-exclude = [ "*vendor*" ]
+
+[tool.ruff.lint]
+preview = true
+explicit-preview-rules = true
+extend-select = ["E", "E303", "W391"]

--- a/tools/dvsim/python/uv.lock
+++ b/tools/dvsim/python/uv.lock
@@ -1,0 +1,789 @@
+version = 1
+revision = 3
+requires-python = "==3.13.*"
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "ansicon"
+version = "1.89.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/e2/1c866404ddbd280efedff4a9f15abfe943cb83cde6e895022370f3a61f85/ansicon-1.89.0.tar.gz", hash = "sha256:e4d039def5768a47e4afec8e89e83ec3ae5a26bf00ad851f914d1240b444d2b1", size = 67312, upload-time = "2019-04-29T20:23:57.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/f9/f1c10e223c7b56a38109a3f2eb4e7fe9a757ea3ed3a166754fb30f65e466/ansicon-1.89.0-py2.py3-none-any.whl", hash = "sha256:f1def52d17f65c2c9682cf8370c03f541f410c1752d6a14029f97318e4b9dfec", size = 63675, upload-time = "2019-04-29T20:23:53.83Z" },
+]
+
+[[package]]
+name = "anybadge"
+version = "1.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/08/ddad0d5398d0961d506b0489e737a06e29a963eff0f2f0a2bb2cfb36dd1f/anybadge-1.16.0.tar.gz", hash = "sha256:f4e95eca834482f9932f9020ac2fe04a5ca863728b446324a8d35b1e67faab71", size = 34616, upload-time = "2025-01-11T23:03:27.966Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/7d/01b2ac2fec808dea667b8678938156c3910219f2c45ee2e0b01e72786d72/anybadge-1.16.0-py3-none-any.whl", hash = "sha256:bc9ef2e20d875ee09237a15250a17b6fd7e67276f083d32a297963cdec179918", size = 28412, upload-time = "2025-01-11T23:03:24.857Z" },
+]
+
+[[package]]
+name = "argcomplete"
+version = "3.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/c0/c8e94135e66fabf89a120d9b4b123fe6993506beca6c1938a74c24cfa5fd/argcomplete-3.7.0.tar.gz", hash = "sha256:afde224f753f874807b1dc1414e883ab8fe0cda9c04807b6047dcb8e1ac23913", size = 73284, upload-time = "2026-06-30T22:28:22.249Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/f6/5b8ec087cd9cfa9449491ec83f76fb6b7006b4dff57d2ba8aaab330fe8e4/argcomplete-3.7.0-py3-none-any.whl", hash = "sha256:d8f0f22d2a8a7caa383be1e22b6caf1ecaf0ebd10d8f83cc125e36540c95830c", size = 42575, upload-time = "2026-06-30T22:28:20.547Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "blessed"
+version = "1.46.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinxed" },
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/ad/ff81f81dc9ed2efbeab4cdecda9f551834429d737ac40c3847b2b1200002/blessed-1.46.0.tar.gz", hash = "sha256:171ee6775a9be86bb000f2e22034c08f76851feb60934a2922feeaff43d0fa60", size = 14034378, upload-time = "2026-07-03T23:43:09.944Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/8f/c10d44ba50d5d298699c3c5698ce4e89b397ec72e2139381b9964f87356c/blessed-1.46.0-py3-none-any.whl", hash = "sha256:558334e2456300332cff9f2b211656cd3eecd3f56a5b1ee5f6110ed83c28e25d", size = 130757, upload-time = "2026-07-03T23:43:07.598Z" },
+]
+
+[[package]]
+name = "caliptra-dvsim"
+version = "0.0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "compile-to-core" },
+    { name = "dvsim" },
+    { name = "flake8" },
+    { name = "fusesoc" },
+    { name = "isort" },
+    { name = "mypy" },
+    { name = "ruff" },
+    { name = "yapf" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "compile-to-core", git = "https://github.com/lowRISC/compile-to-core?branch=main" },
+    { name = "dvsim", specifier = "==1.49.9" },
+    { name = "flake8", specifier = "~=7.1" },
+    { name = "fusesoc", specifier = "==2.4.5" },
+    { name = "isort", specifier = "~=5.10" },
+    { name = "mypy", specifier = "==0.991" },
+    { name = "ruff", specifier = ">=0.9.6" },
+    { name = "yapf", specifier = "==0.32.0" },
+]
+
+[[package]]
+name = "click"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "compile-to-core"
+version = "0.0.1"
+source = { git = "https://github.com/lowRISC/compile-to-core?branch=main#c5505904f119f0ed5a53f79f0b8436e04c3321fe" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "pyyaml" },
+]
+
+[[package]]
+name = "contourpy"
+version = "1.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/35/0167aad910bbdb9599272bd96d01a9ec6852f36b9455cf2ca67bd4cc2d23/contourpy-1.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:177fb367556747a686509d6fef71d221a4b198a3905fe824430e5ea0fda54eb5", size = 293257, upload-time = "2025-07-26T12:01:39.367Z" },
+    { url = "https://files.pythonhosted.org/packages/96/e4/7adcd9c8362745b2210728f209bfbcf7d91ba868a2c5f40d8b58f54c509b/contourpy-1.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d002b6f00d73d69333dac9d0b8d5e84d9724ff9ef044fd63c5986e62b7c9e1b1", size = 274034, upload-time = "2025-07-26T12:01:40.645Z" },
+    { url = "https://files.pythonhosted.org/packages/73/23/90e31ceeed1de63058a02cb04b12f2de4b40e3bef5e082a7c18d9c8ae281/contourpy-1.3.3-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:348ac1f5d4f1d66d3322420f01d42e43122f43616e0f194fc1c9f5d830c5b286", size = 334672, upload-time = "2025-07-26T12:01:41.942Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/93/b43d8acbe67392e659e1d984700e79eb67e2acb2bd7f62012b583a7f1b55/contourpy-1.3.3-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:655456777ff65c2c548b7c454af9c6f33f16c8884f11083244b5819cc214f1b5", size = 381234, upload-time = "2025-07-26T12:01:43.499Z" },
+    { url = "https://files.pythonhosted.org/packages/46/3b/bec82a3ea06f66711520f75a40c8fc0b113b2a75edb36aa633eb11c4f50f/contourpy-1.3.3-cp313-cp313-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:644a6853d15b2512d67881586bd03f462c7ab755db95f16f14d7e238f2852c67", size = 385169, upload-time = "2025-07-26T12:01:45.219Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/32/e0f13a1c5b0f8572d0ec6ae2f6c677b7991fafd95da523159c19eff0696a/contourpy-1.3.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4debd64f124ca62069f313a9cb86656ff087786016d76927ae2cf37846b006c9", size = 362859, upload-time = "2025-07-26T12:01:46.519Z" },
+    { url = "https://files.pythonhosted.org/packages/33/71/e2a7945b7de4e58af42d708a219f3b2f4cff7386e6b6ab0a0fa0033c49a9/contourpy-1.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a15459b0f4615b00bbd1e91f1b9e19b7e63aea7483d03d804186f278c0af2659", size = 1332062, upload-time = "2025-07-26T12:01:48.964Z" },
+    { url = "https://files.pythonhosted.org/packages/12/fc/4e87ac754220ccc0e807284f88e943d6d43b43843614f0a8afa469801db0/contourpy-1.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ca0fdcd73925568ca027e0b17ab07aad764be4706d0a925b89227e447d9737b7", size = 1403932, upload-time = "2025-07-26T12:01:51.979Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/2e/adc197a37443f934594112222ac1aa7dc9a98faf9c3842884df9a9d8751d/contourpy-1.3.3-cp313-cp313-win32.whl", hash = "sha256:b20c7c9a3bf701366556e1b1984ed2d0cedf999903c51311417cf5f591d8c78d", size = 185024, upload-time = "2025-07-26T12:01:53.245Z" },
+    { url = "https://files.pythonhosted.org/packages/18/0b/0098c214843213759692cc638fce7de5c289200a830e5035d1791d7a2338/contourpy-1.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:1cadd8b8969f060ba45ed7c1b714fe69185812ab43bd6b86a9123fe8f99c3263", size = 226578, upload-time = "2025-07-26T12:01:54.422Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/9a/2f6024a0c5995243cd63afdeb3651c984f0d2bc727fd98066d40e141ad73/contourpy-1.3.3-cp313-cp313-win_arm64.whl", hash = "sha256:fd914713266421b7536de2bfa8181aa8c699432b6763a0ea64195ebe28bff6a9", size = 193524, upload-time = "2025-07-26T12:01:55.73Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/b3/f8a1a86bd3298513f500e5b1f5fd92b69896449f6cab6a146a5d52715479/contourpy-1.3.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:88df9880d507169449d434c293467418b9f6cbe82edd19284aa0409e7fdb933d", size = 306730, upload-time = "2025-07-26T12:01:57.051Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/11/4780db94ae62fc0c2053909b65dc3246bd7cecfc4f8a20d957ad43aa4ad8/contourpy-1.3.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:d06bb1f751ba5d417047db62bca3c8fde202b8c11fb50742ab3ab962c81e8216", size = 287897, upload-time = "2025-07-26T12:01:58.663Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/15/e59f5f3ffdd6f3d4daa3e47114c53daabcb18574a26c21f03dc9e4e42ff0/contourpy-1.3.3-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e4e6b05a45525357e382909a4c1600444e2a45b4795163d3b22669285591c1ae", size = 326751, upload-time = "2025-07-26T12:02:00.343Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/81/03b45cfad088e4770b1dcf72ea78d3802d04200009fb364d18a493857210/contourpy-1.3.3-cp313-cp313t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ab3074b48c4e2cf1a960e6bbeb7f04566bf36b1861d5c9d4d8ac04b82e38ba20", size = 375486, upload-time = "2025-07-26T12:02:02.128Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ba/49923366492ffbdd4486e970d421b289a670ae8cf539c1ea9a09822b371a/contourpy-1.3.3-cp313-cp313t-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6c3d53c796f8647d6deb1abe867daeb66dcc8a97e8455efa729516b997b8ed99", size = 388106, upload-time = "2025-07-26T12:02:03.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/52/5b00ea89525f8f143651f9f03a0df371d3cbd2fccd21ca9b768c7a6500c2/contourpy-1.3.3-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:50ed930df7289ff2a8d7afeb9603f8289e5704755c7e5c3bbd929c90c817164b", size = 352548, upload-time = "2025-07-26T12:02:05.165Z" },
+    { url = "https://files.pythonhosted.org/packages/32/1d/a209ec1a3a3452d490f6b14dd92e72280c99ae3d1e73da74f8277d4ee08f/contourpy-1.3.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:4feffb6537d64b84877da813a5c30f1422ea5739566abf0bd18065ac040e120a", size = 1322297, upload-time = "2025-07-26T12:02:07.379Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/9e/46f0e8ebdd884ca0e8877e46a3f4e633f6c9c8c4f3f6e72be3fe075994aa/contourpy-1.3.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2b7e9480ffe2b0cd2e787e4df64270e3a0440d9db8dc823312e2c940c167df7e", size = 1391023, upload-time = "2025-07-26T12:02:10.171Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/70/f308384a3ae9cd2209e0849f33c913f658d3326900d0ff5d378d6a1422d2/contourpy-1.3.3-cp313-cp313t-win32.whl", hash = "sha256:283edd842a01e3dcd435b1c5116798d661378d83d36d337b8dde1d16a5fc9ba3", size = 196157, upload-time = "2025-07-26T12:02:11.488Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/dd/880f890a6663b84d9e34a6f88cded89d78f0091e0045a284427cb6b18521/contourpy-1.3.3-cp313-cp313t-win_amd64.whl", hash = "sha256:87acf5963fc2b34825e5b6b048f40e3635dd547f590b04d2ab317c2619ef7ae8", size = 240570, upload-time = "2025-07-26T12:02:12.754Z" },
+    { url = "https://files.pythonhosted.org/packages/80/99/2adc7d8ffead633234817ef8e9a87115c8a11927a94478f6bb3d3f4d4f7d/contourpy-1.3.3-cp313-cp313t-win_arm64.whl", hash = "sha256:3c30273eb2a55024ff31ba7d052dde990d7d8e5450f4bbb6e913558b3d6c2301", size = 199713, upload-time = "2025-07-26T12:02:14.4Z" },
+]
+
+[[package]]
+name = "cycler"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/95/a3dbbb5028f35eafb79008e7522a75244477d2838f38cbb722248dabc2a8/cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c", size = 7615, upload-time = "2023-10-07T05:32:18.335Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30", size = 8321, upload-time = "2023-10-07T05:32:16.783Z" },
+]
+
+[[package]]
+name = "dvsim"
+version = "1.49.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anybadge" },
+    { name = "click" },
+    { name = "enlighten" },
+    { name = "gitpython" },
+    { name = "hjson" },
+    { name = "jinja2" },
+    { name = "matplotlib" },
+    { name = "plotly" },
+    { name = "psutil" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "tabulate" },
+    { name = "toml" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/c8/12e4cde18c3fc9b4f526bedcbf1f6f5d660a03663af871ed04a06ed3a388/dvsim-1.49.9.tar.gz", hash = "sha256:a4e416d522ad526f6893a4b998a366116c0b4049737721cc71d1e1a0d77fcd9f", size = 545992, upload-time = "2026-06-04T12:49:34.119Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/bf/2045971014fe978fdebd381ed84350f01e10c49e9d9c8e757340c486ad10/dvsim-1.49.9-py3-none-any.whl", hash = "sha256:a80a2bde9558e165c66e9a3c3a526324e8cf94965d6dc055be98bc0f91010c95", size = 306546, upload-time = "2026-06-04T12:49:32.283Z" },
+]
+
+[[package]]
+name = "edalize"
+version = "0.6.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/77/e7b0f6b96c6eafdb798a8b7a4c76c064522d94aecb7fc0ea442ff7d6291b/edalize-0.6.8.tar.gz", hash = "sha256:d1d2b9d441789c718e7480c9c4ce55fd39b463f2a7f0f328da1daed7179b1e72", size = 397573, upload-time = "2026-04-24T21:18:51.276Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/35/dc7aeba94c4514394ecd8528e271a6dcdf92c41106b4bc03c84b0f7f9dd9/edalize-0.6.8-py3-none-any.whl", hash = "sha256:e8d8287358dac914fa68d388c468dd62eb39f7d1402c95bdb89f85a73593c0ba", size = 179483, upload-time = "2026-04-24T21:18:48.557Z" },
+]
+
+[[package]]
+name = "enlighten"
+version = "1.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "blessed" },
+    { name = "prefixed" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8d/87/50b1152a85e3dca202e9e28ba2594c03edce8b9e74187b3aef5b98e4b631/enlighten-1.14.1.tar.gz", hash = "sha256:85c35412a9a4f3886b3337d41f813441fab9a30d9f5b5f0c015bd078a4411473", size = 68562, upload-time = "2025-03-10T18:03:35.042Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/1e/244bb2fc5713ad21ae9f9012067f6432c682593816c6a45372c24f5a7d61/enlighten-1.14.1-py2.py3-none-any.whl", hash = "sha256:5fbd0c959ca1644034c41bb0ace5db19c9852cf9d721b6103f5f130663c57be8", size = 42281, upload-time = "2025-03-10T18:03:33.478Z" },
+]
+
+[[package]]
+name = "fastjsonschema"
+version = "2.21.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/b5/23b216d9d985a956623b6bd12d4086b60f0059b27799f23016af04a74ea1/fastjsonschema-2.21.2.tar.gz", hash = "sha256:b1eb43748041c880796cd077f1a07c3d94e93ae84bba5ed36800a33554ae05de", size = 374130, upload-time = "2025-08-14T18:49:36.666Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/a8/20d0723294217e47de6d9e2e40fd4a9d2f7c4b6ef974babd482a59743694/fastjsonschema-2.21.2-py3-none-any.whl", hash = "sha256:1c797122d0a86c5cace2e54bf4e819c36223b552017172f32c5c024a6b77e463", size = 24024, upload-time = "2025-08-14T18:49:34.776Z" },
+]
+
+[[package]]
+name = "flake8"
+version = "7.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mccabe" },
+    { name = "pycodestyle" },
+    { name = "pyflakes" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/af/fbfe3c4b5a657d79e5c47a2827a362f9e1b763336a52f926126aa6dc7123/flake8-7.3.0.tar.gz", hash = "sha256:fe044858146b9fc69b551a4b490d69cf960fcb78ad1edcb84e7fbb1b4a8e3872", size = 48326, upload-time = "2025-06-20T19:31:35.838Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/56/13ab06b4f93ca7cac71078fbe37fcea175d3216f31f85c3168a6bbd0bb9a/flake8-7.3.0-py2.py3-none-any.whl", hash = "sha256:b9696257b9ce8beb888cdbe31cf885c90d31928fe202be0889a7cdafad32f01e", size = 57922, upload-time = "2025-06-20T19:31:34.425Z" },
+]
+
+[[package]]
+name = "fonttools"
+version = "4.63.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/69/c97f2c18e0db87d2c7b15da1974dace76ae938f1cfa22e2727a648b7ed43/fonttools-4.63.0.tar.gz", hash = "sha256:caeb583deeb5168e694b65cda8b4ee62abedfa66cf88488734466f2366b9c4e0", size = 3597189, upload-time = "2026-05-14T12:04:30.958Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/8d/d8fec3dcde2963f8c908fb315e5ff2cd0ac34f82394bbbf73a2aa5145ce3/fonttools-4.63.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:cd7e9857e5e63738b9d9fd707bc1f59c8b09e5177726d23664db393c59bb08bd", size = 2876062, upload-time = "2026-05-14T12:03:32.554Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/71/d935dc54e4ff121bfdd11e08702db63a7e6f25af21d8a3d7b7212df53641/fonttools-4.63.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c2a2a42198b696a6f48fad91709afb55176e66a5e566131219dba372fb7f8c59", size = 2424594, upload-time = "2026-05-14T12:03:34.86Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/40/e76320afa1df918e146155ef239b1719ee266092e96f5423bfd075affba1/fonttools-4.63.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e874792a8212b44583ea02189d9e693906b2f78b261f372f95d6c563210ac1d", size = 5024840, upload-time = "2026-05-14T12:03:36.745Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/36/0b805d8c485f872f65a509cbe3b58a5d0d17bee855333b54a150c79d3061/fonttools-4.63.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:22135da48a348785c5e2d5d2d9d6bec5ed44adacbaeb9db12d9493bf6c6bfa68", size = 4975801, upload-time = "2026-05-14T12:03:38.833Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/26/2cee03d0aa083ab022da5c07aff9ed3f689da1defb81ad6917c9627896da/fonttools-4.63.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ccf41f2efdf56994d22d73bef4ced1052161958169428d06ba9724ea9e9a64be", size = 4965009, upload-time = "2026-05-14T12:03:41.494Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/48/cc4b66d9058c0d0982c833fad10127c4b0e9324606aafa41382295ca4102/fonttools-4.63.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9ced0bd02ac751dd6319b0da88aaef24414e3b0dbc32bb4f24944821a3741a27", size = 5105892, upload-time = "2026-05-14T12:03:43.525Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/1f/a98a30a814b9ddef3a2e706025f90b9e0bc94890e6cb15254bc86547d11a/fonttools-4.63.0-cp313-cp313-win32.whl", hash = "sha256:85be818f5506e8a7753153def2c9550178f0ecae6a47b5e0e8dbb23f7cc90380", size = 2291313, upload-time = "2026-05-14T12:03:45.594Z" },
+    { url = "https://files.pythonhosted.org/packages/92/46/5177b01f3b4abfdd4409f31cca4ab279c9343a26efbe9ec78c97fc612e02/fonttools-4.63.0-cp313-cp313-win_amd64.whl", hash = "sha256:ba04cb5891d4c0c21b6da95eda8d7b090021508a294fff33464fc7d241e0856b", size = 2342299, upload-time = "2026-05-14T12:03:47.414Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/47/c99d5268f354002ce80f8d029cd9d7d872969da1de8b93d32de4dc56d6f4/fonttools-4.63.0-py3-none-any.whl", hash = "sha256:445af2eab030a16b9171ea8bdda7ebf7d96bda2df88ee182a464252f6e05e20d", size = 1164562, upload-time = "2026-05-14T12:04:29.092Z" },
+]
+
+[[package]]
+name = "fusesoc"
+version = "2.4.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argcomplete" },
+    { name = "edalize" },
+    { name = "fastjsonschema" },
+    { name = "pyparsing" },
+    { name = "pyyaml" },
+    { name = "simplesat" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/97/becad1ace06d63316935362c46f198d2552680f2d41e4189bcec826a3cdf/fusesoc-2.4.5.tar.gz", hash = "sha256:5418c9ef0884cf8e35895aae2cc19a6ed7586cad3bf9db47634e71f10cdd48bf", size = 191664, upload-time = "2025-11-13T12:54:22.945Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/46/93275f4b1be9b1967bfa0262b963497dee9ddb8f8ea89882c30a0f83d056/fusesoc-2.4.5-py3-none-any.whl", hash = "sha256:008fc9c512643fbfe2dc19ef9f543e12f4543c0b8135eefc1359f4e82ce69d8a", size = 66390, upload-time = "2025-11-13T12:54:20.713Z" },
+]
+
+[[package]]
+name = "gitdb"
+version = "4.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "smmap" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/63b0fc47eb32792c7ba1fe1b694daec9a63620db1e313033d18140c2320a/gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571", size = 394684, upload-time = "2025-01-02T07:20:46.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf", size = 62794, upload-time = "2025-01-02T07:20:43.624Z" },
+]
+
+[[package]]
+name = "gitpython"
+version = "3.1.50"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gitdb" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
+]
+
+[[package]]
+name = "hjson"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/e5/0b56d723a76ca67abadbf7fb71609fb0ea7e6926e94fcca6c65a85b36a0e/hjson-3.1.0.tar.gz", hash = "sha256:55af475a27cf83a7969c808399d7bccdec8fb836a07ddbd574587593b9cdcf75", size = 40541, upload-time = "2022-08-13T02:53:01.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/7f/13cd798d180af4bf4c0ceddeefba2b864a63c71645abc0308b768d67bb81/hjson-3.1.0-py3-none-any.whl", hash = "sha256:65713cdcf13214fb554eb8b4ef803419733f4f5e551047c9b711098ab7186b89", size = 54018, upload-time = "2022-08-13T02:52:59.899Z" },
+]
+
+[[package]]
+name = "isort"
+version = "5.13.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/87/f9/c1eb8635a24e87ade2efce21e3ce8cd6b8630bb685ddc9cdaca1349b2eb5/isort-5.13.2.tar.gz", hash = "sha256:48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109", size = 175303, upload-time = "2023-12-13T20:37:26.124Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/b3/8def84f539e7d2289a02f0524b944b15d7c75dab7628bedf1c4f0992029c/isort-5.13.2-py3-none-any.whl", hash = "sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6", size = 92310, upload-time = "2023-12-13T20:37:23.244Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jinxed"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ansicon", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/d7/6e6d474ec5eaeca6a61acc17766bb19563b3a372b4b9d92910078f5fe49f/jinxed-2.1.0.tar.gz", hash = "sha256:7e755b831faa2443d44fb4ce7c0202eb9c3ed39bd5bf1193365888f4f6092b54", size = 61287, upload-time = "2026-07-03T15:46:48.153Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/1d/0a6be99b69bb448448403a45a241aff0dca751832ae54f027ed940d2eb52/jinxed-2.1.0-py2.py3-none-any.whl", hash = "sha256:43b802d18b70e405d410fb66eb2837d1101e7e5ea922e666507bb43f34d11d09", size = 104999, upload-time = "2026-07-03T15:46:47.114Z" },
+]
+
+[[package]]
+name = "kiwisolver"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/67/9c61eccb13f0bdca9307614e782fec49ffdde0f7a2314935d489fa93cd9c/kiwisolver-1.5.0.tar.gz", hash = "sha256:d4193f3d9dc3f6f79aaed0e5637f45d98850ebf01f7ca20e69457f3e8946b66a", size = 103482, upload-time = "2026-03-09T13:15:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/69/024d6711d5ba575aa65d5538042e99964104e97fa153a9f10bc369182bc2/kiwisolver-1.5.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:fd40bb9cd0891c4c3cb1ddf83f8bbfa15731a248fdc8162669405451e2724b09", size = 123166, upload-time = "2026-03-09T13:13:48.032Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/adbb40df306f587054a348831220812b9b1d787aff714cfbc8556e38fccd/kiwisolver-1.5.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c0e1403fd7c26d77c1f03e096dc58a5c726503fa0db0456678b8668f76f521e3", size = 66395, upload-time = "2026-03-09T13:13:49.365Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/3a/d0a972b34e1c63e2409413104216cd1caa02c5a37cb668d1687d466c1c45/kiwisolver-1.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:dda366d548e89a90d88a86c692377d18d8bd64b39c1fb2b92cb31370e2896bbd", size = 64065, upload-time = "2026-03-09T13:13:50.562Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0a/7b98e1e119878a27ba8618ca1e18b14f992ff1eda40f47bccccf4de44121/kiwisolver-1.5.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:332b4f0145c30b5f5ad9374881133e5aa64320428a57c2c2b61e9d891a51c2f3", size = 1477903, upload-time = "2026-03-09T13:13:52.084Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d8/55638d89ffd27799d5cc3d8aa28e12f4ce7a64d67b285114dbedc8ea4136/kiwisolver-1.5.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c50b89ffd3e1a911c69a1dd3de7173c0cd10b130f56222e57898683841e4f96", size = 1278751, upload-time = "2026-03-09T13:13:54.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/97/b4c8d0d18421ecceba20ad8701358453b88e32414e6f6950b5a4bad54e65/kiwisolver-1.5.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4db576bb8c3ef9365f8b40fe0f671644de6736ae2c27a2c62d7d8a1b4329f099", size = 1296793, upload-time = "2026-03-09T13:13:56.287Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/10/f862f94b6389d8957448ec9df59450b81bec4abb318805375c401a1e6892/kiwisolver-1.5.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0b85aad90cea8ac6797a53b5d5f2e967334fa4d1149f031c4537569972596cb8", size = 1346041, upload-time = "2026-03-09T13:13:58.269Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/6a/f1650af35821eaf09de398ec0bc2aefc8f211f0cda50204c9f1673741ba9/kiwisolver-1.5.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:d36ca54cb4c6c4686f7cbb7b817f66f5911c12ddb519450bbe86707155028f87", size = 987292, upload-time = "2026-03-09T13:13:59.871Z" },
+    { url = "https://files.pythonhosted.org/packages/de/19/d7fb82984b9238115fe629c915007be608ebd23dc8629703d917dbfaffd4/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:38f4a703656f493b0ad185211ccfca7f0386120f022066b018eb5296d8613e23", size = 2227865, upload-time = "2026-03-09T13:14:01.401Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/b9/46b7f386589fd222dac9e9de9c956ce5bcefe2ee73b4e79891381dda8654/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3ac2360e93cb41be81121755c6462cff3beaa9967188c866e5fce5cf13170859", size = 2324369, upload-time = "2026-03-09T13:14:02.972Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8b/95e237cf3d9c642960153c769ddcbe278f182c8affb20cecc1cc983e7cc5/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c95cab08d1965db3d84a121f1c7ce7479bdd4072c9b3dafd8fecce48a2e6b902", size = 1977989, upload-time = "2026-03-09T13:14:04.503Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/95/980c9df53501892784997820136c01f62bc1865e31b82b9560f980c0e649/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:fc20894c3d21194d8041a28b65622d5b86db786da6e3cfe73f0c762951a61167", size = 2491645, upload-time = "2026-03-09T13:14:06.106Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/32/900647fd0840abebe1561792c6b31e6a7c0e278fc3973d30572a965ca14c/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7a32f72973f0f950c1920475d5c5ea3d971b81b6f0ec53b8d0a956cc965f22e0", size = 2295237, upload-time = "2026-03-09T13:14:08.891Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8a/be60e3bbcf513cc5a50f4a3e88e1dcecebb79c1ad607a7222877becaa101/kiwisolver-1.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:0bf3acf1419fa93064a4c2189ac0b58e3be7872bf6ee6177b0d4c63dc4cea276", size = 73573, upload-time = "2026-03-09T13:14:12.327Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/d2/64be2e429eb4fca7f7e1c52a91b12663aeaf25de3895e5cca0f47ef2a8d0/kiwisolver-1.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:fa8eb9ecdb7efb0b226acec134e0d709e87a909fa4971a54c0c4f6e88635484c", size = 64998, upload-time = "2026-03-09T13:14:13.469Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/69/ce68dd0c85755ae2de490bf015b62f2cea5f6b14ff00a463f9d0774449ff/kiwisolver-1.5.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:db485b3847d182b908b483b2ed133c66d88d49cacf98fd278fadafe11b4478d1", size = 125700, upload-time = "2026-03-09T13:14:14.636Z" },
+    { url = "https://files.pythonhosted.org/packages/74/aa/937aac021cf9d4349990d47eb319309a51355ed1dbdc9c077cdc9224cb11/kiwisolver-1.5.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:be12f931839a3bdfe28b584db0e640a65a8bcbc24560ae3fdb025a449b3d754e", size = 67537, upload-time = "2026-03-09T13:14:15.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/20/3a87fbece2c40ad0f6f0aefa93542559159c5f99831d596050e8afae7a9f/kiwisolver-1.5.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:16b85d37c2cbb3253226d26e64663f755d88a03439a9c47df6246b35defbdfb7", size = 65514, upload-time = "2026-03-09T13:14:18.035Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7f/f943879cda9007c45e1f7dba216d705c3a18d6b35830e488b6c6a4e7cdf0/kiwisolver-1.5.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4432b835675f0ea7414aab3d37d119f7226d24869b7a829caeab49ebda407b0c", size = 1584848, upload-time = "2026-03-09T13:14:19.745Z" },
+    { url = "https://files.pythonhosted.org/packages/37/f8/4d4f85cc1870c127c88d950913370dd76138482161cd07eabbc450deff01/kiwisolver-1.5.0-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b0feb50971481a2cc44d94e88bdb02cdd497618252ae226b8eb1201b957e368", size = 1391542, upload-time = "2026-03-09T13:14:21.54Z" },
+    { url = "https://files.pythonhosted.org/packages/04/0b/65dd2916c84d252b244bd405303220f729e7c17c9d7d33dca6feeff9ffc4/kiwisolver-1.5.0-cp313-cp313t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:56fa888f10d0f367155e76ce849fa1166fc9730d13bd2d65a2aa13b6f5424489", size = 1404447, upload-time = "2026-03-09T13:14:23.205Z" },
+    { url = "https://files.pythonhosted.org/packages/39/5c/2606a373247babce9b1d056c03a04b65f3cf5290a8eac5d7bdead0a17e21/kiwisolver-1.5.0-cp313-cp313t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:940dda65d5e764406b9fb92761cbf462e4e63f712ab60ed98f70552e496f3bf1", size = 1455918, upload-time = "2026-03-09T13:14:24.74Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/d1/c6078b5756670658e9192a2ef11e939c92918833d2745f85cd14a6004bdf/kiwisolver-1.5.0-cp313-cp313t-manylinux_2_39_riscv64.whl", hash = "sha256:89fc958c702ee9a745e4700378f5d23fddbc46ff89e8fdbf5395c24d5c1452a3", size = 1072856, upload-time = "2026-03-09T13:14:26.597Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/c8/7def6ddf16eb2b3741d8b172bdaa9af882b03c78e9b0772975408801fa63/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9027d773c4ff81487181a925945743413f6069634d0b122d0b37684ccf4f1e18", size = 2333580, upload-time = "2026-03-09T13:14:28.237Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/87/2ac1fce0eb1e616fcd3c35caa23e665e9b1948bb984f4764790924594128/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:5b233ea3e165e43e35dba1d2b8ecc21cf070b45b65ae17dd2747d2713d942021", size = 2423018, upload-time = "2026-03-09T13:14:30.018Z" },
+    { url = "https://files.pythonhosted.org/packages/67/13/c6700ccc6cc218716bfcda4935e4b2997039869b4ad8a94f364c5a3b8e63/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ce9bf03dad3b46408c08649c6fbd6ca28a9fce0eb32fdfffa6775a13103b5310", size = 2062804, upload-time = "2026-03-09T13:14:32.888Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bd/877056304626943ff0f1f44c08f584300c199b887cb3176cd7e34f1515f1/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:fc4d3f1fb9ca0ae9f97b095963bc6326f1dbfd3779d6679a1e016b9baaa153d3", size = 2597482, upload-time = "2026-03-09T13:14:34.971Z" },
+    { url = "https://files.pythonhosted.org/packages/75/19/c60626c47bf0f8ac5dcf72c6c98e266d714f2fbbfd50cf6dab5ede3aaa50/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f443b4825c50a51ee68585522ab4a1d1257fac65896f282b4c6763337ac9f5d2", size = 2394328, upload-time = "2026-03-09T13:14:36.816Z" },
+    { url = "https://files.pythonhosted.org/packages/47/84/6a6d5e5bb8273756c27b7d810d47f7ef2f1f9b9fd23c9ee9a3f8c75c9cef/kiwisolver-1.5.0-cp313-cp313t-win_arm64.whl", hash = "sha256:893ff3a711d1b515ba9da14ee090519bad4610ed1962fbe298a434e8c5f8db53", size = 68410, upload-time = "2026-03-09T13:14:38.695Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+]
+
+[[package]]
+name = "matplotlib"
+version = "3.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "contourpy" },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/24/080c99d223d158d3a8902769269ab6da5b50f7a0e6e072513907e02b7a6c/matplotlib-3.11.0.tar.gz", hash = "sha256:68c0c7be01b30dcca3638934f7f591df73401235cbdbf0d1ab1c71e7db7f8b57", size = 33251176, upload-time = "2026-06-12T02:29:15.508Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/41/aa47f156b061d14c98b906f76c428507397708ec63ff94f410ae1752b426/matplotlib-3.11.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6ce3b839b34ae1f430b4616893a2945a2999debaa7e94e7e29a2a8bbf286f7b5", size = 9450532, upload-time = "2026-06-12T02:28:06.769Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/4f/5a9eb0375e81413953febf8af7b012a6b6357f53438a15c4f5ad86c6bbb5/matplotlib-3.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:373db8f91214e8ccaf35ac833cc1dd59dd961e148bbd55dd027141591dde1313", size = 9279760, upload-time = "2026-06-12T02:28:09.152Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/c0/1117d53077e3ac3152503a84e9cf7a5c239576805ee71276e80c2aaa7471/matplotlib-3.11.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:be152b7570324dc8d01574cc9474dd2d803237acf528bcbb5b211fa347461a09", size = 10031623, upload-time = "2026-06-12T02:28:11.26Z" },
+    { url = "https://files.pythonhosted.org/packages/92/7e/e937138daffad65b71bf831a377809dcbc830fb4f31a31e067dc1faa2575/matplotlib-3.11.0-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:126f256df600652d7e4b394cf3164ff75210a00038f287c95a012a6f58d0e83f", size = 10839372, upload-time = "2026-06-12T02:28:14.102Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/c2/438ecc197ffb8023b6b9922915542f2172f5fd45b76703b0b4fc47322243/matplotlib-3.11.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:03acfeddf87b0dddb11b081ef7740ad445a3ca8bcb6b8e3011b08f2cf802b75c", size = 10924099, upload-time = "2026-06-12T02:28:16.383Z" },
+    { url = "https://files.pythonhosted.org/packages/40/2e/395883da416f378b3ed2c9f3e843ac477eae1ce731b671b79adaa6f0bacd/matplotlib-3.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:ab3722f04f3ff34c23b5012c5873d2894174e06c3822fcdac3610965a5ac7d06", size = 9329727, upload-time = "2026-06-12T02:28:18.581Z" },
+    { url = "https://files.pythonhosted.org/packages/61/82/2c388956abf8bf392dfb5b8917c502f1082df6a941b781ab8c8e5ba2474b/matplotlib-3.11.0-cp313-cp313-win_arm64.whl", hash = "sha256:c945824670fb8915b4ac879e5e61f3c58e0913022f70a0de4c082b17372f8771", size = 9003506, upload-time = "2026-06-12T02:28:20.474Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c1/34454baa44da7975ada82e9aea37105ec47059514dc967d3be14426ba8dc/matplotlib-3.11.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:3489c3dc487669b4a980bc3068f87856de7a1564248d3f6c629efb2a58b03f24", size = 9499838, upload-time = "2026-06-12T02:28:22.713Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/c3/98fe79a398cf232219f090163a7fa7e6766e9f2e0ad26df54d6f8934d8ee/matplotlib-3.11.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:6a98f5476ce784a50ce09998f4ae1e6a9f25043cef8a480c98949902eda74620", size = 9332298, upload-time = "2026-06-12T02:28:24.796Z" },
+    { url = "https://files.pythonhosted.org/packages/95/e4/b4b7c33151e74e5c802f3cde1ba807ebfc38401e329b44e215a5888dd76d/matplotlib-3.11.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:565af866fd63e4bd3f987d580afe27c44c2552a3b3305f4ecbb85133601ea6f3", size = 10045491, upload-time = "2026-06-12T02:28:27.141Z" },
+    { url = "https://files.pythonhosted.org/packages/71/28/394548efd68354110c1a1be11fe6b6e559e06d1a23da35908a0e316c55a9/matplotlib-3.11.0-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e6b3e64dea5062c570f04358e2711859f3531b459f29516274fbad889079e4f3", size = 10857059, upload-time = "2026-06-12T02:28:29.222Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/44/e7922e6e2a4d63bdfbc9dc4a53e3850ab438d46cf42e6779bb15ec92c948/matplotlib-3.11.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:942b37c5db1899610bd1543ce8e13e4ecff9a4633e7f63bb6aa9205d2644ebd1", size = 10939576, upload-time = "2026-06-12T02:28:31.66Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/be/b1ca96003a441d619b727fee21d671fdff7a5ce2f1bb797b2521aa2f679a/matplotlib-3.11.0-cp313-cp313t-win_amd64.whl", hash = "sha256:c08e649a6313e1291e713623b97a38e5bb4aa580b2a100a94a3309bc6b9c8eb3", size = 9379519, upload-time = "2026-06-12T02:28:33.888Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/72/4bf3b91821c34596dd6a7bdac5836d94f744144c8208939ef49d8ec43f7e/matplotlib-3.11.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2746cd2c113742ff6ce37a864c5ac5fd7aa644568f445e66166e457ac78e40e0", size = 9055456, upload-time = "2026-06-12T02:28:35.878Z" },
+]
+
+[[package]]
+name = "mccabe"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "0.991"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mypy-extensions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/5c/fbe112ca73d4c6a9e65336f48099c60800514d8949b4129c093a84a28dc8/mypy-0.991.tar.gz", hash = "sha256:3c0165ba8f354a6d9881809ef29f1a9318a236a6d81c690094c5df32107bde06", size = 2688198, upload-time = "2022-11-14T16:59:24.952Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/a1/c503a15ad69ff133a76c159b8287f0eadc1f521d9796bf81f935886c98f6/mypy-0.991-py3-none-any.whl", hash = "sha256:de32edc9b0a7e67c2775e574cb061a537660e51210fbf6006b0b36ea695ae9bb", size = 2307767, upload-time = "2022-11-14T16:56:33.004Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "narwhals"
+version = "2.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/ac/66ed1fc6e38a0c0f330627ec5c5d597990d6159b6712b82af0ad2c65f06c/narwhals-2.23.0.tar.gz", hash = "sha256:13e7ff5b4bb4a2f77b907c2e4d8a76e273dfc1323a3c997440a2f9fd26aed408", size = 656209, upload-time = "2026-07-01T11:21:53.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/4e/afc8c31605cb8be1d3bb4438c4d979daa104dab6306cd2b87abe9c3a7299/narwhals-2.23.0-py3-none-any.whl", hash = "sha256:769e7b9ab102c93d8fa019f6b4cd1a657909b04a20bf6210e5a35aae06814ae9", size = 458938, upload-time = "2026-07-01T11:21:51.677Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/07/ec2a3f0c91761581d4b7104a740791800025983f9a4dc4e73f91a99aeac4/numpy-2.5.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0bfebd8695f9863592fe744be833a258120b14a9f39da255e8aa8fade2c0ddd1", size = 16796419, upload-time = "2026-07-04T17:06:40.37Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ab/ddb499fc4f8780354395face5b65c7fd107bcd6e1d667a5f07d046956f6f/numpy-2.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:30b44a6b53a7ae63c54c089a8726e5563ed302716c5b7ccc85afade40b0e7ff6", size = 11765832, upload-time = "2026-07-04T17:06:42.768Z" },
+    { url = "https://files.pythonhosted.org/packages/88/b3/3c28c558a09fc72100c646dac6d2fce8e834c471b0edca01a29996706117/numpy-2.5.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:6165343f81b56ef8f514f396989e529b61d9dc709b99421b07e9f3e698e2287d", size = 5325143, upload-time = "2026-07-04T17:06:45.466Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/0e/ce19b985bb15c596f4f05954e76cccc77c845083b3b8f938a6c68e523128/numpy-2.5.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4939237038ada79308dda3204ac6462df056b5672b2e25db1149cf873668b3e1", size = 6659749, upload-time = "2026-07-04T17:06:47.288Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/20/1ee6614d64332a1bba6411f38e68cb79eec1b2459e20a623777c5c5492a2/numpy-2.5.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c6759f538fb912fc46de0a6b1758ccf7b57bc7c7ebebc23974fdac3de8db0cd", size = 15164716, upload-time = "2026-07-04T17:06:49.494Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a7/2bcd3fdbb87804755c35b729bf8709d62025c5f4cfd7d5b2415997097515/numpy-2.5.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9726558e8db4a5bf7929a70ae50f63abda4daf0efe810e3bfbab95976f75fc1a", size = 16661440, upload-time = "2026-07-04T17:06:52.061Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/d7/a41e3310c886fe457d36e670bbf24fae411aca8a7b6ad92a32afd924077c/numpy-2.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3935f3b419b244a02732676fa5317a9193cc596a4c0646db07e5b421229ac9f7", size = 16526305, upload-time = "2026-07-04T17:06:54.605Z" },
+    { url = "https://files.pythonhosted.org/packages/53/75/4333a9a707c1edd3a4e1a0c58eca52c0f31e55089fa80db02b5565b24df7/numpy-2.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dc932a65ded7ce9013d120845a2514dcccb1a67bfc8deb8d37633762951904a6", size = 18423008, upload-time = "2026-07-04T17:06:57.54Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/e314a32b1c11a2ffe818ddad3a57b50b4b6e1b6c487192eb50cdef0415d0/numpy-2.5.1-cp313-cp313-win32.whl", hash = "sha256:4b4ff1608417eb7a59da7b967bbb798cacfe071d2caf526a24281cd562072ed9", size = 6063885, upload-time = "2026-07-04T17:07:00.14Z" },
+    { url = "https://files.pythonhosted.org/packages/10/70/800b3fca480af32df9e8ea9f3d4a0c8feb4b32d7f195d174eabbda4829ad/numpy-2.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:6c3fe51bc6a16453d452997053454f309e8e0ed7b42d6b361ce4ac8c32913d74", size = 12425674, upload-time = "2026-07-04T17:07:02.387Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/0b/196350c122f50f6ca56846f2d71efd5e0d24b7b2e07355e019b2e2c7a11e/numpy-2.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:f7feb014281029e628ba2d5a007407443b06e418b6fe451d1e2adcbc8eba0107", size = 10350256, upload-time = "2026-07-04T17:07:04.878Z" },
+]
+
+[[package]]
+name = "okonomiyaki"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/95/2a3cde9beff788a9ec34d64525e509e3ae4d4053669ae1be30a000fdee5b/okonomiyaki-3.0.0.tar.gz", hash = "sha256:f5de606542d27821fda1a59c4e13dfa9adf227a0e4dc28a408e280918b54b70e", size = 8285132, upload-time = "2025-02-14T17:52:17.02Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/d2/c7e021fb8e591fa586a8aa8fd8728ffded2f80deebf6198cd1bd92c68447/okonomiyaki-3.0.0-py2.py3-none-any.whl", hash = "sha256:a5193286e9db0ded2d3ae80d7c3ebb9923bca89e94ba03d612bb9c2c0948cd77", size = 8372945, upload-time = "2025-02-14T17:52:09.245Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pillow"
+version = "12.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/3d/bb7fca845737cf9d7dbde16ed1843984665ff2e0a518f5db43e77ec540b9/pillow-12.3.0.tar.gz", hash = "sha256:3b8182a766685eaa002637e28b4ec8d6b18819a0c71f579bf0dbaa5830297cce", size = 47025035, upload-time = "2026-07-01T11:56:38.965Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/ac/31fb64e1e7efb5a4b50cd3d92049ba89ac6e4d8d3bb6a74e15048ca3353e/pillow-12.3.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:21900ce7ba264168cd50defae43cd75d25c833ad4ad6e73ffc5596d12e25ac89", size = 4161684, upload-time = "2026-07-01T11:54:25.934Z" },
+    { url = "https://files.pythonhosted.org/packages/87/b4/9805e23d2b4d77842b468513841fda254ee42f0289d25088340e4ff46e2d/pillow-12.3.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:4e8c2a84d977f50b9daed6eeaf3baef67d00d5d74d932288f02cb94518ee3ace", size = 4255487, upload-time = "2026-07-01T11:54:27.935Z" },
+    { url = "https://files.pythonhosted.org/packages/df/39/ecf519435a200c693fe053a6ee4d835b41cf963a4dfc2551c4e637cb2a71/pillow-12.3.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:ae26d61dfa7a47befdc7572b521024e8745f3d809bd95ca9505a7bba9ef849ec", size = 3696433, upload-time = "2026-07-01T11:54:29.813Z" },
+    { url = "https://files.pythonhosted.org/packages/42/92/2fc3ffad878ae8dd5469ec1bc8eb83b71f48e13efdf68f02709003982a32/pillow-12.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7a743ff716f746fc19a9557f60dab1600d4613255f8a7aeb3cdde4db7eb15a66", size = 5345889, upload-time = "2026-07-01T11:54:31.97Z" },
+    { url = "https://files.pythonhosted.org/packages/10/76/8803c13605b763d33d156c4678fc77f8443389c0c51c8aef707bb02015f4/pillow-12.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d69141514cc30b774ceea5e3ed3a6635c8d8a96edf664689b890f4089111fb35", size = 4780109, upload-time = "2026-07-01T11:54:34.026Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/01/e18aff37cb0b4aac47ac90f016d347a49aca667ef97f190b06ac2aabc928/pillow-12.3.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f7401aebd7f581d7f83a439d87d474999317ee099218e5ad25d125290990ba65", size = 6263736, upload-time = "2026-07-01T11:54:36.131Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/62/de5bdd77d935331f4f802edc11e4d82950f642caad6cb2f949837b8560e2/pillow-12.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0847a763afefb695bc912d7c131e7e0632d4edc1d8698f58ddabec8e46b8b6d3", size = 6937129, upload-time = "2026-07-01T11:54:38.216Z" },
+    { url = "https://files.pythonhosted.org/packages/70/4d/105627a13300c5e0df1d174230b32fd1273062c96f7745fd552b945d1e1d/pillow-12.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:571b9fcb07b97ef3a492028fb3d2dc0993ca23a06138b0315286566d29ef718a", size = 6339562, upload-time = "2026-07-01T11:54:40.354Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/1d/f13de01a553988ab895ba1c722e06cf3144d4f57656fd5b81b6d881f1179/pillow-12.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:756c768d0c9c2955feb7a56c37ea24aea2e369f8d36a88da270b6a9f19e62b5e", size = 7049439, upload-time = "2026-07-01T11:54:42.489Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/f9/066794cca041b969964f779ee5fa66a9498bbf34248ac39c5d7954e4198f/pillow-12.3.0-cp313-cp313-win32.whl", hash = "sha256:a876864214e136f0eb367788dbd7df045f4806801518e2cfe9e13229cfe06d8f", size = 6473287, upload-time = "2026-07-01T11:54:44.9Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/9b/7a58e61d62be561da3a356fe2384d4059a6345fc130e23ef1c36a5b81d24/pillow-12.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:1cca606cd25738df4ed873d5ad46bbdb3d83b5cbca291f6b4ff13a4df6b0bbe8", size = 7239691, upload-time = "2026-07-01T11:54:47.141Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b0/c4ed4f0ef8f8fa5ee8351537db6650bb8189f7e118842978dd6589065692/pillow-12.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:b629de27fda84b42cde7edef0d85f13b958b47f6e9bbcbba9b673c562a89bd8b", size = 2568185, upload-time = "2026-07-01T11:54:49.137Z" },
+]
+
+[[package]]
+name = "plotly"
+version = "6.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "narwhals" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/fd/d72c292d78aadb93d1a9bcd76bf3c678271040c7cf10abe5788b33040a39/plotly-6.8.0.tar.gz", hash = "sha256:e088e7ddc68d4f70e3d66659224727a45296d71d2b8284181862d3d8f1f0d88f", size = 6915161, upload-time = "2026-06-03T18:33:40.226Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/14/abe5ce876ab5b66ee3c691bf537fcd43d037aea55d447aacf74630a8f31e/plotly-6.8.0-py3-none-any.whl", hash = "sha256:13c5c4a0f70b74cab1913eda0de49b826df5931708eb6f9c3010040614700ec8", size = 9902055, upload-time = "2026-06-03T18:33:34.26Z" },
+]
+
+[[package]]
+name = "prefixed"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/ae/296470eca349da35bdec573e54320afa2b5b099c582e5d97be8bccac247e/prefixed-0.9.0.tar.gz", hash = "sha256:164403fa9ebc83280bbc4705f4b243a28837e164310b4e65c38ccab1ebafeeb3", size = 99277, upload-time = "2024-09-02T18:56:25.248Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/61/d9957a0ed189ac8a89075c59c97588fb1c77e51d8d44a26f5cdf001d260c/prefixed-0.9.0-py2.py3-none-any.whl", hash = "sha256:3cdb74bfc4cf0aba28f3574662b13afdcac27c463dcbef320fe5d03f4c5fbca8", size = 13509, upload-time = "2024-09-02T18:56:23.47Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
+name = "pycodestyle"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/e0/abfd2a0d2efe47670df87f3e3a0e2edda42f055053c85361f19c0e2c1ca8/pycodestyle-2.14.0.tar.gz", hash = "sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783", size = 39472, upload-time = "2025-06-20T18:49:48.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/27/a58ddaf8c588a3ef080db9d0b7e0b97215cee3a45df74f3a94dbbf5c893a/pycodestyle-2.14.0-py2.py3-none-any.whl", hash = "sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d", size = 31594, upload-time = "2025-06-20T18:49:47.491Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+]
+
+[[package]]
+name = "pyflakes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/dc/fd034dc20b4b264b3d015808458391acbf9df40b1e54750ef175d39180b1/pyflakes-3.4.0.tar.gz", hash = "sha256:b24f96fafb7d2ab0ec5075b7350b3d2d2218eab42003821c06344973d3ea2f58", size = 64669, upload-time = "2025-06-20T18:45:27.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/2f/81d580a0fb83baeb066698975cb14a618bdbed7720678566f1b046a95fe8/pyflakes-3.4.0-py2.py3-none-any.whl", hash = "sha256:f742a7dbd0d9cb9ea41e9a24a918996e8170c799fa528688d40dd582c8265f4f", size = 63551, upload-time = "2025-06-20T18:45:26.937Z" },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/dc/35b341fc554ba02f217fc10da57d1a75168cfbcf75b0ef2202176d4c4f2d/ruff-0.15.20.tar.gz", hash = "sha256:1416eb04349192646b54de98f146c4f59afe37d0decfc02c3cbbf396f3a28566", size = 4755489, upload-time = "2026-06-25T17:20:37.578Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/d9/2d5014f0253ba541d2061d9fa7193f48e941c8b21bb88a7ff9bbe0bd0596/ruff-0.15.20-py3-none-linux_armv6l.whl", hash = "sha256:00e188c53e499c3c1637f73c91dcf2fb56d576cab76ce1be50a27c4e80e37078", size = 10839665, upload-time = "2026-06-25T17:19:44.702Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/d3/ac1798ba64f670698867fcfc591d50e7e421bef137db564858f619a30fcf/ruff-0.15.20-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9ebd1fd9b9c95fc0bd7b2761aebec1f030013d2e193a2901b224af68fe47251b", size = 11208649, upload-time = "2026-06-25T17:19:48.787Z" },
+    { url = "https://files.pythonhosted.org/packages/47/47/d3ac899991202095dfcf3d5176be4272642be3cf981a2f1a30f72a2afb95/ruff-0.15.20-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c5b16cdd67ca108185cd36dce98c576350c03b1660a751de725fb049193a0632", size = 10622638, upload-time = "2026-06-25T17:19:51.354Z" },
+    { url = "https://files.pythonhosted.org/packages/33/13/4e043fe30aa94d4ff5213a9881fc296d12960f5971b234a5263fdc225312/ruff-0.15.20-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3413bb3c3d2ca6a8208f1f4809cd2dca3c6de6d0b491c0e70847672bde6e6efd", size = 10984227, upload-time = "2026-06-25T17:19:54.044Z" },
+    { url = "https://files.pythonhosted.org/packages/76/e6/92e7bf40388bc5800073b96564f56264f7e48bfd1a498f5ced6ae6d5a769/ruff-0.15.20-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bd7ec42b3bb3da066488db093308a69c4ac5ee6d2af333a86ba6e2eb2e7dd44b", size = 10622882, upload-time = "2026-06-25T17:19:57.037Z" },
+    { url = "https://files.pythonhosted.org/packages/13/7a/43460be3f24495a3aa46d4b16873e2c4941b3b5f0b00cf88c03b7b94b339/ruff-0.15.20-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e1a36ad0eb77fba9aabfb69ede54de6f376d04ac18ebea022847046d340a8267", size = 11474808, upload-time = "2026-06-25T17:20:00.357Z" },
+    { url = "https://files.pythonhosted.org/packages/27/a0/f37077884873221c6b33b4ab49eb18f9f88e54a16a25a5bca59bef46dd66/ruff-0.15.20-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b6df3b1e4610432f0386dba04d853b5f08cbbc903410c6fcc02f620f05aff53c", size = 12293094, upload-time = "2026-06-25T17:20:03.446Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/74/165545b60256a9704c21ac0ec4a0d07933b320812f9584836c9f4aca4292/ruff-0.15.20-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e89f198a1ea6ef0d727c1cf16088bc91a6cb0ab947dedc966715691647186eae", size = 11526176, upload-time = "2026-06-25T17:20:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/86/b1/a976a136d40ade83ce743578399865f57001003a409acadc0ecbb3051082/ruff-0.15.20-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:309809086c2acb67624950a3c8133e80f32d0d3e27106c0cd60ff26657c9f24b", size = 11520767, upload-time = "2026-06-25T17:20:09.191Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0f/f032696cb01c9b54c0263fa393474d7758f1cdc021a01b04e3cbc2500999/ruff-0.15.20-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2d2374caa2f2c2f9e2b7da0a50802cfb8b79f55a9b5e49379f564544fbf56487", size = 11500132, upload-time = "2026-06-25T17:20:13.602Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f4/51b1a14bc69e8c224b15dab9cce8e99b425e0455d462caa2b3c9be2b6a8e/ruff-0.15.20-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a1ed17b65293e0c2f22fc387bc13198a5de94bf4429589b0ff6946b0feaf21a3", size = 10943828, upload-time = "2026-06-25T17:20:16.635Z" },
+    { url = "https://files.pythonhosted.org/packages/71/4b/fe267640783cd02bf6c5cc290b1df1051be2ec294c678b5c15fe19e52343/ruff-0.15.20-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f701305e66b38ea6c91882490eb73459796808e4c6362a1b765255e0cdcd4053", size = 10645418, upload-time = "2026-06-25T17:20:19.4Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c0/a65aa4ec2f5e87a1df32dc3ec1fede434fe3dfd5cbcf3b503cafc676ab54/ruff-0.15.20-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5b9c0c367ad8e5d0d5b5b8537864c469a0a0e55417aadfbeca41fa61333be9f4", size = 11211770, upload-time = "2026-06-25T17:20:22.033Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/a4/0caa331d954ae2723d729d351c989cb4ca8b6077d5c6c2cb6de75e98c041/ruff-0.15.20-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:01cc00dd58f0df339d0e902219dd53990ea99996a0344e5d9cc8d45d5307e460", size = 11618698, upload-time = "2026-06-25T17:20:25.259Z" },
+    { url = "https://files.pythonhosted.org/packages/10/9b/5f14927848d2fd4aa891fd88d883788c5a7baba561c7874732364045708c/ruff-0.15.20-py3-none-win32.whl", hash = "sha256:ed65ef510e43a137207e0f01cfcf998aeddb1aeeda5c9d35023e910284d7cf21", size = 10857322, upload-time = "2026-06-25T17:20:28.612Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f0/fe47c501f9dea92a26d788ff98bb5d92ed4cb4c88792c5c88af6b697dc8e/ruff-0.15.20-py3-none-win_amd64.whl", hash = "sha256:a525c81c70fb0380344dd1d8745d8cc1c890b7fc94a58d5a07bd8eb9557b8415", size = 11993274, upload-time = "2026-06-25T17:20:31.871Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/2b/9555445e1201d92b3195f45cdb153a0b68f24e0a4273f6e3d5ab46e212bb/ruff-0.15.20-py3-none-win_arm64.whl", hash = "sha256:2f5b2a6d614e8700388806a14996c40fab2c47b819ef57d790a34878858ed9ca", size = 11343498, upload-time = "2026-06-25T17:20:35.03Z" },
+]
+
+[[package]]
+name = "simplesat"
+version = "0.9.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "okonomiyaki" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/24/60/9c4a2534ae17dc5397c0536c3875a6ea8acf5d65f099ae617ce676433f3b/simplesat-0.9.2.tar.gz", hash = "sha256:8cb800d09289bdc051126e725949368f8ac25105d40865cb93aa20eae9d46a9c", size = 225589, upload-time = "2025-04-03T16:43:22.701Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/62/1fed9c4c0a4c31a8aaaffe68da566fc6c18fb3dcd7991256264e12669354/simplesat-0.9.2-py3-none-any.whl", hash = "sha256:dde724538ccc5bddfdf57aa366cfb0cec0e3cae8c5d1ebc56f4cfb47948a8f97", size = 249125, upload-time = "2025-04-03T16:43:20.726Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "smmap"
+version = "5.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/ea/49c993d6dfdd7338c9b1000a0f36817ed7ec84577ae2e52f890d1a4ff909/smmap-5.0.3.tar.gz", hash = "sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c", size = 22506, upload-time = "2026-03-09T03:43:26.1Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl", hash = "sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f", size = 24390, upload-time = "2026-03-09T03:43:24.361Z" },
+]
+
+[[package]]
+name = "tabulate"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
+]
+
+[[package]]
+name = "toml"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/74/c6428f875774288bec1396f5bfcbc2d925700a4dad61727fd5f2b12f249d/wcwidth-0.8.2.tar.gz", hash = "sha256:91fbef97204b96a3d4d421609b80340b760cf33e26da123ff243d76b1fda8dda", size = 1466253, upload-time = "2026-06-29T18:11:11.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl", hash = "sha256:d63947694a0539a1d51e01eda7caf800c291020e6cdd7e28ad7b14dd33ad4f85", size = 323166, upload-time = "2026-06-29T18:11:09.888Z" },
+]
+
+[[package]]
+name = "yapf"
+version = "0.32.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/cd/d0d1e95b8d78b8097d90ca97af92f4af7fb2e867262a2b6e37d6f48e612a/yapf-0.32.0.tar.gz", hash = "sha256:a3f5085d37ef7e3e004c4ba9f9b3e40c54ff1901cd111f05145ae313a7c67d1b", size = 194820, upload-time = "2021-12-26T07:48:02.924Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/88/843c2e68f18a5879b4fbf37cb99fbabe1ffc4343b2e63191c8462235c008/yapf-0.32.0-py2.py3-none-any.whl", hash = "sha256:8fea849025584e486fd06d6ba2bed717f396080fd3cc236ba10cb97c4c51cf32", size = 190236, upload-time = "2021-12-26T07:48:00.432Z" },
+]

--- a/tools/dvsim/questa.hjson
+++ b/tools/dvsim/questa.hjson
@@ -1,0 +1,115 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  build_cmd:  "{job_prefix} {QUESTA_HOME}/questasim/linux_x86_64/qrun -optimize"
+  run_cmd:    "{job_prefix} {QUESTA_HOME}/questasim/linux_x86_64/qrun -simulate"
+
+
+  build_opts: [ "-timescale 1ns/1ps",
+                "-outdir {build_dir}/qrun.out",
+                "-uvm -uvmhome {QUESTA_HOME}/questasim/verilog_src/uvm-1.2",
+                "-mfcu",
+                "-f {sv_flist}",
+                // List multiple tops for the simulation. Prepend each top level with `-top`.
+                "{eval_cmd} echo {sim_tops} | sed -E 's/(\\S+)/-top \\1/g'",
+                "-voptargs=\"+acc=nr\""
+              ]
+
+  run_opts:   [ "-outdir {build_dir}/qrun.out",
+                "-sv_seed {seed}",
+                // dv_macros.svh has a macro printing null using %0d
+                // format specifier, Questa throws an error on this
+                // we demote this error in Questa
+                "-suppress vsim-8323",
+                // Questa forces all declared virtual interfaces to be allocated,
+                // even in classes that are not even created at runtime. The switch
+                // below demotes the associated error thrown.
+                "-permit_unmatched_virtual_intf",
+                "+UVM_TESTNAME={uvm_test}",
+                "+UVM_TEST_SEQ={uvm_test_seq}",
+                "-do {run_script}"
+              ]
+
+  // Supported wave dumping formats (in order of preference).
+  supported_wave_formats: []
+
+  // Default tcl script used when running the sim. Override if needed.
+  run_script: "{dv_root}/tools/questa/sim.tcl"
+
+  // Coverage related.
+  cov_db_dir: "{scratch_path}/coverage/{build_mode}.ucdb"
+
+  // Individual test specific coverage data - this will be deleted if the test fails
+  // so that coverage from failiing tests is not included in the final report.
+  cov_db_test_dir_name: "{run_dir_name}.{seed}"
+  cov_db_test_dir: "{cov_db_dir}/snps/coverage/db/testdata/{cov_db_test_dir_name}"
+
+  // Merging coverage.
+  // "cov_db_dirs" is a special variable that appends all build directories in use.
+  // It is constructed by the tool itself.
+  cov_merge_dir:    "{scratch_path}/cov_report"
+  cov_merge_db_dir: ""
+  cov_merge_cmd:    ""
+  cov_merge_opts:   []
+
+  // Generate covreage reports in text as well as html.
+  cov_report_dir:       "{scratch_path}/cov_report"
+  cov_report_cmd:       ""
+  cov_report_opts:      []
+  cov_report_txt:   "{cov_report_dir}/dashboard.txt"
+
+  // Analyzing coverage - this is done by invoking --cov-analyze switch. It opens up the
+  // GUI for visual analysis.
+  cov_analyze_dir:  "{scratch_path}/cov_analyze"
+  cov_analyze_cmd:  ""
+  cov_analyze_opts: []
+
+  // By default, collect all coverage metrics.
+  cov_metrics: "bcestf"
+
+  // pass and fail patterns
+  build_fail_patterns: ["^## \\*\\* Error.*$"
+                        "^\\*\\* Error.*$"]
+  run_fail_patterns:   ["^\\*\\* Error.*$"]
+
+  build_modes: [
+   {
+      name: questa_gui
+      is_sim_mode: 1
+      build_opts: []
+      run_opts: ["-gui"]
+    }
+    {
+      name: questa_waves
+      is_sim_mode: 1
+    }
+    // TODO Questa coverage only currently supported in the GUI with no merging
+    {
+      name: questa_cov
+      is_sim_mode: 1
+      build_opts: ["+cover={cov_metrics}"]
+      run_opts:   ["-coverage", "-gui"]
+    }
+    // TODO support profiling for questa
+    {
+      name: questa_profile
+      is_sim_mode: 1
+      build_opts: []
+      run_opts:   []
+    }
+    {
+      name: questa_xprop
+      is_sim_mode: 1
+      build_opts: []
+    }
+    {
+      // TODO: Add build and run options to enable zero delay loop detection.
+      name: questa_loopdetect
+      is_sim_mode: 1
+      build_opts: []
+      run_opts:   []
+    }
+
+  ]
+}

--- a/tools/dvsim/sim.mk
+++ b/tools/dvsim/sim.mk
@@ -1,0 +1,131 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+export SHELL  := /usr/bin/env bash
+.DEFAULT_GOAL := all
+
+all: build run
+
+###############################
+## sim build and run targets ##
+###############################
+build: build_result
+
+pre_build:
+	@echo -e "\n[make]: pre_build"
+	mkdir -p ${build_dir}
+ifneq (${pre_build_cmds},)
+	cd ${build_dir} && ${pre_build_cmds}
+endif
+
+gen_sv_flist: pre_build
+	@echo -e "\n[make]: gen_sv_flist"
+ifneq (${sv_flist_gen_cmd},)
+	cd ${build_dir} && ${sv_flist_gen_cmd} ${sv_flist_gen_opts}
+endif
+
+do_build: gen_sv_flist
+	@echo -e "\n[make]: build"
+	cd ${sv_flist_gen_dir} && ${build_cmd} ${build_opts}
+
+post_build: do_build
+	@echo -e "\n[make]: post_build"
+ifneq (${post_build_cmds},)
+	cd ${build_dir} && ${post_build_cmds} ${post_build_opts}
+endif
+
+build_result: post_build
+	@echo -e "\n[make]: build_result"
+
+run: run_result
+
+pre_run:
+	@echo -e "\n[make]: pre_run"
+	mkdir -p ${run_dir}
+ifneq (${pre_run_cmds},)
+	cd ${run_dir} && ${pre_run_cmds}
+endif
+
+sw_build: pre_run
+	@echo -e "\n[make]: sw_build"
+ifneq (${sw_images},)
+	cd ${proj_root} && ${sw_build_cmd} --build-seed=${build_seed}
+endif
+
+simulate: sw_build
+	@echo -e "\n[make]: simulate"
+	cd ${run_dir} && ${run_cmd} ${run_opts}
+
+post_run: simulate
+	@echo -e "\n[make]: post_run"
+ifneq (${post_run_cmds},)
+	cd ${run_dir} && ${post_run_cmds}
+endif
+
+run_result: post_run
+	@echo -e "\n[make]: run_result"
+
+#######################
+## Load waves target ##
+#######################
+debug_waves:
+	${debug_waves_cmd} ${debug_waves_opts}
+
+############################
+## coverage rated targets ##
+############################
+cov_unr_build: gen_sv_flist
+	@echo -e "\n[make]: cov_unr_build"
+	cd ${sv_flist_gen_dir} && ${cov_unr_build_cmd} ${cov_unr_build_opts}
+
+cov_unr_vcs: cov_unr_build
+	@echo -e "\n[make]: cov_unr"
+	cd ${sv_flist_gen_dir} && ${cov_unr_run_cmd} ${cov_unr_run_opts}
+
+cov_unr_xcelium:
+	@echo -e "\n[make]: cov_unr"
+	mkdir -p ${cov_unr_dir}
+	cd ${cov_unr_dir} && ${cov_unr_run_cmd} ${cov_unr_run_opts}
+
+cov_unr_merge:
+	@echo -e "\n[make]: cov_unr_merge"
+	cd ${cov_unr_dir} && ${job_prefix} ${cov_merge_cmd} -init ${cov_unr_dir}/jgproject/sessionLogs/session_0/unr_imc_coverage_merge.cmd
+
+ifeq (${SIMULATOR}, xcelium)
+  cov_unr: cov_unr_xcelium cov_unr_merge
+else
+  cov_unr: cov_unr_vcs
+endif
+
+# Merge coverage if there are multiple builds.
+cov_merge:
+	@echo -e "\n[make]: cov_merge"
+	${job_prefix} ${cov_merge_cmd} ${cov_merge_opts}
+
+# Generate coverage reports.
+cov_report:
+	@echo -e "\n[make]: cov_report"
+	${cov_report_cmd} ${cov_report_opts}
+
+# Open coverage tool to review and create report or exclusion file.
+cov_analyze:
+	@echo -e "\n[make]: cov_analyze"
+	${cov_analyze_cmd} ${cov_analyze_opts}
+
+.PHONY: build \
+	pre_build \
+	gen_sv_flist \
+	do_build \
+	post_build \
+	build_result \
+	run \
+	pre_run \
+	sw_build \
+	simulate \
+	post_run \
+	run_result \
+	debug_waves \
+	cov_merge \
+	cov_analyze \
+	cov_report

--- a/tools/dvsim/testplans/csr_testplan.hjson
+++ b/tools/dvsim/testplans/csr_testplan.hjson
@@ -1,0 +1,116 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  testpoints: [
+    {
+      name: csr_hw_reset
+      desc: '''
+            Verify the reset values as indicated in the RAL specification.
+            - Write all CSRs with a random value.
+            - Apply reset to the DUT as well as the RAL model.
+            - Read each CSR and compare it against the reset value.
+              it is mandatory to replicate this test for each reset that affects
+              all or a subset of the CSRs.
+            - It is mandatory to run this test for all available interfaces the
+              CSRs are accessible from.
+            - Shuffle the list of CSRs first to remove the effect of ordering.
+            '''
+      stage: V1
+      tests: ["{name}{intf}_csr_hw_reset"]
+    }
+    {
+      name: csr_rw
+      desc: '''
+            Verify accessibility of CSRs as indicated in the RAL specification.
+            - Loop through each CSR to write it with a random value.
+            - Read the CSR back and check for correctness while adhering to its
+              access policies.
+            - It is mandatory to run this test for all available interfaces the
+              CSRs are accessible from.
+            - Shuffle the list of CSRs first to remove the effect of ordering.
+            '''
+      stage: V1
+      tests: ["{name}{intf}_csr_rw"]
+    }
+    {
+      name: csr_bit_bash
+      desc: '''
+            Verify no aliasing within individual bits of a CSR.
+            - Walk a 1 through each CSR by flipping 1 bit at a time.
+            - Read the CSR back and check for correctness while adhering to its
+              access policies.
+            - This verify that writing a specific bit within the CSR did not affect
+              any of the other bits.
+            - It is mandatory to run this test for all available interfaces the
+              CSRs are accessible from.
+            - Shuffle the list of CSRs first to remove the effect of ordering.
+            '''
+      stage: V1
+      tests: ["{name}{intf}_csr_bit_bash"]
+    }
+    {
+      name: csr_aliasing
+      desc: '''
+            Verify no aliasing within the CSR address space.
+            - Loop through each CSR to write it with a random value
+            - Shuffle and read ALL CSRs back.
+            - All CSRs except for the one that was written in this iteration should
+              read back the previous value.
+            - The CSR that was written in this iteration is checked for correctness
+              while adhering to its access policies.
+            - It is mandatory to run this test for all available interfaces the
+              CSRs are accessible from.
+            - Shuffle the list of CSRs first to remove the effect of ordering.
+            '''
+      stage: V1
+      tests: ["{name}{intf}_csr_aliasing"]
+    }
+    {
+      name: csr_mem_rw_with_rand_reset
+      desc: '''
+            Verify random reset during CSR/memory access.
+            - Run csr_rw sequence to randomly access CSRs
+            - If memory exists, run mem_partial_access in parallel with csr_rw
+            - Randomly issue reset and then use hw_reset sequence to check all CSRs
+              are reset to default value
+            - It is mandatory to run this test for all available interfaces the
+              CSRs are accessible from.
+            '''
+      stage: V1
+      tests: ["{name}{intf}_csr_mem_rw_with_rand_reset"]
+    }
+    {
+      name: regwen_csr_and_corresponding_lockable_csr
+      desc: '''
+            Verify regwen CSR and its corresponding lockable CSRs.
+            - Randomly access all CSRs
+            - Test when regwen CSR is set, its corresponding lockable CSRs become
+              read-only registers
+
+            Note:
+            - If regwen CSR is HW read-only, this feature can be fully tested by common
+              CSR tests - csr_rw and csr_aliasing.
+            - If regwen CSR is HW updated, a separate test should be created to test it.
+
+            This is only applicable if the block contains regwen and locakable CSRs.
+            '''
+      stage: V1
+      tests: ["{name}{intf}_csr_rw", "{name}{intf}_csr_aliasing"]
+    }
+  ]
+  covergroups: [
+    {
+      name: regwen_val_when_new_value_written_cg
+      desc: '''
+            Cover each lockable reg field with these 2 cases:
+            - When regwen = 1, a different value is written to the lockable CSR field, and a read
+              occurs after that.
+            - When regwen = 0, a different value is written to the lockable CSR field, and a read
+              occurs after that.
+
+            This is only applicable if the block contains regwen and locakable CSRs.
+            '''
+    }
+  ]
+}

--- a/tools/dvsim/testplans/fpv_csr_testplan.hjson
+++ b/tools/dvsim/testplans/fpv_csr_testplan.hjson
@@ -1,0 +1,17 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  testpoints: [
+    {
+      name: fpv_csr_rw
+      desc: '''
+            Write assertions to verify all the CSRs. Each CSR will include a read assertion to ensure
+            the read value from the bus is expected, and a write assertion to ensure the write value
+            is updated correctly to DUT according to the register's access.
+            '''
+      stage: V2
+      tests: ["{name}{intf}_fpv_csr_rw"]
+    }
+  ]
+}

--- a/tools/dvsim/testplans/intr_test_testplan.hjson
+++ b/tools/dvsim/testplans/intr_test_testplan.hjson
@@ -1,0 +1,26 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  testpoints: [
+    {
+      name: intr_test
+      desc: '''
+            Verify common intr_test CSRs that allows SW to mock-inject interrupts.
+            - Enable a random set of interrupts by writing random value(s) to
+              intr_enable CSR(s).
+            - Randomly "turn on" interrupts by writing random value(s) to intr_test
+              CSR(s).
+            - Read all intr_state CSR(s) back to verify that it reflects the same value
+              as what was written to the corresponding intr_test CSR.
+            - Check the cfg.intr_vif pins to verify that only the interrupts that were
+              enabled and turned on are set.
+            - Clear a random set of interrupts by writing a randomly value to intr_state
+              CSR(s).
+            - Repeat the above steps a bunch of times.
+            '''
+      stage: V2
+      tests: ["{name}{intf}_intr_test"]
+    }
+  ]
+}

--- a/tools/dvsim/tests/csr_tests.hjson
+++ b/tools/dvsim/tests/csr_tests.hjson
@@ -1,0 +1,84 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  build_modes: [
+    {
+      name: cover_reg_top
+    }
+  ]
+
+  run_modes: [
+    {
+      name: csr_tests_mode
+      uvm_test_seq: "{name}_common_vseq"
+      run_opts: ["+en_scb=0"]
+    }
+  ]
+
+  tests: [
+    {
+      name: "{name}_csr_hw_reset"
+      build_mode: "cover_reg_top"
+      run_opts: ["+csr_hw_reset"]
+      en_run_modes: ["csr_tests_mode"]
+      reseed: 1
+    }
+
+    {
+      name: "{name}_csr_rw"
+      build_mode: "cover_reg_top"
+      run_opts: ["+csr_rw"]
+      en_run_modes: ["csr_tests_mode"]
+      reseed: 5
+    }
+
+    {
+      name: "{name}_csr_bit_bash"
+      build_mode: "cover_reg_top"
+      run_opts: ["+csr_bit_bash"]
+      en_run_modes: ["csr_tests_mode"]
+      reseed: 1
+    }
+
+    {
+      name: "{name}_csr_aliasing"
+      build_mode: "cover_reg_top"
+      run_opts: ["+csr_aliasing"]
+      en_run_modes: ["csr_tests_mode"]
+      reseed: 1
+    }
+
+    {
+      name: "{name}_same_csr_outstanding"
+      build_mode: "cover_reg_top"
+      run_opts: ["+run_same_csr_outstanding"]
+      en_run_modes: ["csr_tests_mode"]
+      reseed: 5
+    }
+
+    {
+      name: "{name}_csr_mem_rw_with_rand_reset"
+      build_mode: "cover_reg_top"
+      run_opts: ["+run_csr_mem_rw_with_rand_reset", "+test_timeout_ns=10000000000"]
+      en_run_modes: ["csr_tests_mode"]
+      reseed: 5
+    }
+  ]
+
+  regressions: [
+    {
+      name: smoke
+      tests: ["{name}_csr_hw_reset", "{name}_csr_rw"]
+    }
+
+    {
+      name: sw_access
+      tests: ["{name}_csr_hw_reset",
+              "{name}_csr_rw",
+              "{name}_csr_bit_bash",
+              "{name}_csr_aliasing",
+              "{name}_same_csr_outstanding"]
+    }
+  ]
+}

--- a/tools/dvsim/tests/intr_test.hjson
+++ b/tools/dvsim/tests/intr_test.hjson
@@ -1,0 +1,20 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  build_modes: [
+    {
+      name: cover_reg_top
+    }
+  ]
+
+  tests: [
+    {
+      name: "{name}_intr_test"
+      build_mode: "cover_reg_top"
+      uvm_test_seq: "{name}_common_vseq"
+      run_opts: ["+run_intr_test"]
+      reseed: 10
+    }
+  ]
+}

--- a/tools/dvsim/tools/common.tcl
+++ b/tools/dvsim/tools/common.tcl
@@ -1,0 +1,73 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Commonly used globals & procs. This file must be sourced first.
+set simulator ""
+if {[info exists ::env(SIMULATOR)]} {
+  set simulator "$::env(SIMULATOR)"
+} else {
+  puts "ERROR: tool script run without SIMULATOR environment variable."
+  quit
+}
+
+set waves "none"
+if {[info exists ::env(WAVES)]} {
+  set waves "$::env(WAVES)"
+}
+
+set gui 0
+if {[info exists ::env(GUI)]} {
+  set gui "$::env(GUI)"
+}
+
+set gui_debug 0
+# Detect when GUI debug mode has been invoked to build UVM objects by default
+if {[info exists ::env(GUI_DEBUG)]} {
+  set gui_debug "$::env(GUI_DEBUG)"
+}
+
+set tb_top "tb"
+if {[info exists ::env(TB_TOP)]} {
+  set tb_top "$::env(TB_TOP)"
+} else {
+  puts "WARNING: TB_TOP environment variable not set - using \"tb\" as the
+        top level testbench hierarchy."
+}
+
+# Checks if variable is defined, else throw an error and exit.
+proc checkVarExists {var} {
+  upvar $var var_
+  if {![info exists var_]} {
+    puts "ERROR: Variable \"$var\" not found."
+    quit
+  }
+}
+
+# If variable is defined, then use it, else set the default value.
+proc setDefault {var value} {
+  upvar $var var_
+  if {[info exists var_]} {
+    puts "INFO: \"$var\" is already set to \"$var_\"."
+  } else {
+    puts "INFO: Setting \"$var\" to \"$value\"."
+    set var_ $value
+  }
+  return $var_
+}
+
+proc checkEq {var value} {
+  upvar $var var_
+  if {$var_ != $value} {
+    puts "ERROR: Check failed \"$var\" == \"$value\"!. Actual: \"$var_\"."
+    quit
+  }
+}
+
+proc checkNe {var value} {
+  upvar $var var_
+  if {$var_ == $value} {
+    puts "ERROR: Check failed \"$var\" != \"$value\"!. Actual: \"$var_\"."
+    quit
+  }
+}

--- a/tools/dvsim/tools/questa/sim.tcl
+++ b/tools/dvsim/tools/questa/sim.tcl
@@ -1,0 +1,18 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+
+# Remove leading "# " from the front of log file lines and run the test if not in gui mode.
+# This provides compatibility for log file error checking with other supported simulators within Opentitan.
+set gui 0
+if {[info exists ::env(GUI)]} {
+  set gui "$::env(GUI)"
+}
+
+if {$gui == 0} {
+  set PrefMain(LinePrefix) ""
+  run -all
+} else {
+  set PrefMain(LinePrefix) ""
+}

--- a/tools/dvsim/tools/sim.tcl
+++ b/tools/dvsim/tools/sim.tcl
@@ -1,0 +1,60 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Common TCL script invoked at run-time by the simulator.
+# VCS syntax: -ucli -do <this file>
+# Xcelium syntax: -input <this file>
+
+set dv_root ""
+if {[info exists ::env(dv_root)]} {
+  set dv_root "$::env(dv_root)"
+} else {
+  puts "ERROR: Script run without dv_root environment variable."
+  quit
+}
+
+# Dumping waves in specific hierarchies.
+#
+# By default, if wave dumping is enabled, all hierarchies of the top level testbench are dumped.
+# For large designs, this may slow down the simulation considerably. To bypass this and only enable
+# waves in specific hierarchies, set the dump_tb_top flag to 0 (i.e. uncomment the line below), and
+# specify the paths to dump on line 32.
+# set dump_tb_top 0
+
+source "${dv_root}/tools/common.tcl"
+source "${dv_root}/tools/waves.tcl"
+
+global waves
+global simulator
+global tb_top
+
+# Dumping waves in specific hierarchies (example):
+# wavedumpScope $waves $simulator tb.dut.foo.bar 12
+# wavedumpScope $waves $simulator tb.dut.baz 0
+
+if {$simulator eq "xcelium"} {
+  puts "INFO: The following assertions are permamently disabled:"
+  assertion -list -depth all -multiline -permoff $tb_top
+}
+
+global gui
+global gui_debug
+# In GUI mode, let the user take control of running the simulation.
+# In GUI debug mode, run only up until the end of the UVM elaboration phase to have access to the
+# dynamic objects.
+if {$gui_debug == 1} {
+  if {$simulator eq "xcelium"} {
+    uvm_phase -stop_at build -end
+    run
+  }
+} elseif {$gui == 0} {
+  run
+  if {$simulator eq "xcelium"} {
+    # Xcelium provides a `finish` tcl command instead of `quit`. The argument '2' enables the
+    # logging of additional resource usage information.
+    finish 2
+  } else {
+    quit
+  }
+}

--- a/tools/dvsim/tools/vcs/common_cov_excl.cfg
+++ b/tools/dvsim/tools/vcs/common_cov_excl.cfg
@@ -1,0 +1,3 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0

--- a/tools/dvsim/tools/vcs/cover.cfg
+++ b/tools/dvsim/tools/vcs/cover.cfg
@@ -1,0 +1,3 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0

--- a/tools/dvsim/tools/vcs/cover_reg_top.cfg
+++ b/tools/dvsim/tools/vcs/cover_reg_top.cfg
@@ -1,0 +1,3 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0

--- a/tools/dvsim/tools/vcs/fsm_reset_cov.cfg
+++ b/tools/dvsim/tools/vcs/fsm_reset_cov.cfg
@@ -1,0 +1,7 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is used with -cm_fsmresetfilter to exclude FSM transitions that can only happen on
+// reset.
+// Format: signal=<reset_signal_name> case=TRUE/FALSE (indicates reset is high/low active)

--- a/tools/dvsim/tools/vcs/unr.cfg
+++ b/tools/dvsim/tools/vcs/unr.cfg
@@ -1,0 +1,24 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+-covInput $SCRATCH_PATH/cov_merge/merged.vdb
+-covDUT $dut_instance
+
+# Provide the clock specification
+-clock clk_i 100
+# Provide the reset specification: signal_name, active_value, num clk cycles reset to be active
+-reset rst_ni 0 20
+
+# Enables the Elite licensing for UNR
+# Adding this switch avoids the compile error saying could not find the `VC-static-cov` license
+-fmlElite
+
+# Black box common security modules
+ -blackBoxes -type design prim_count+prim_spare_fsm+prim_double_lfsr
+
+# Name of the generated exclusion file
+-save_exclusion $SCRATCH_PATH/cov_unr/unr_exclude.el
+
+# Enables verbose reporting in addition to summary reporting.
+-verboseReport

--- a/tools/dvsim/tools/vcs/xprop.cfg
+++ b/tools/dvsim/tools/vcs/xprop.cfg
@@ -1,0 +1,12 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Use most pessimistic X propagation.
+merge = xmerge;
+
+// Turn on xprop for dut only.
+instance { tb.dut } { xpropOn };
+
+// Modules excluded from xprop instrumentation.
+module { prim_cdc_rand_delay } { xpropOff };

--- a/tools/dvsim/tools/waves.tcl
+++ b/tools/dvsim/tools/waves.tcl
@@ -1,0 +1,163 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# This is sourced by all supported simulators. The driver scripts
+# (dvsim) need to make sure that we don't ask for an unsupported
+# dumping format (SHM with VCS, for example). The adjoining common.tcl
+# must be sourced prior to sourcing this file.
+
+if {[info proc setDefault] ne "setDefault"} {
+  puts "ERROR: Please ensure that common.tcl is sourced."
+  quit
+}
+
+# A procedure that provides a wave-format-agnostic way to enable a scope (design heirarchy).
+#
+# In large designs, dumping waves on the entire hierarchy can significantly slow down the
+# simulation. It is useful in that case to only dump the relevant scopes of interest during debug.
+#
+# waves       : The wave-format (fsdb, shm, vpd, vcd, evcd, etc).
+# simulator   : The simulator used for running the simulation (vcs, xcelium, etc).
+# scope       : Design / testbench hierarchy to dump waves. Defaults to $tb_top.
+# depth       : Levels in the hierarchy to dump waves. Defaults to 0 (dump all levels).
+# fsdb_flags  : Additional string flags passed to fsdbDumpVars. Defaults to "+all", which enables
+#               dumping of memories, MDAs, structs, unions, power, packed structs, and SVAs.
+# probe_flags : Additional string flags passed to probe command (Xcelium). Defaults to "-all".
+# dump_flags  : Additional string flags passed to dump command (VCS). Defaults to "-aggregates",
+#               which enables dumping of structs and arrays.
+#
+# Depending on the need, more such technology specific flags can be added in future.
+proc wavedumpScope {waves simulator scope {depth 0} {fsdb_flags "+all"} {probe_flags "-all"}
+                    {dump_flags "-aggregates"}} {
+
+  switch $waves {
+    "none" {
+      return
+    }
+
+    "fsdb" {
+      if {$simulator eq "xcelium"} {
+        call fsdbDumpvars $depth $scope $fsdb_flags
+        call fsdbDumpSVA $depth $scope
+      } else {
+        fsdbDumpvars $depth $scope $fsdb_flags
+        fsdbDumpSVA $depth $scope
+      }
+    }
+
+    "shm" {
+      if {$depth == 0} {
+        set depth "all"
+      }
+      probe "$scope" $probe_flags -depth $depth -memories -shm
+    }
+
+    "vpd" {
+      global vpd_fid
+      dump -add "$scope" -fid $vpd_fid -depth $depth $dump_flags
+    }
+
+    "vcd" {
+      if {$simulator eq "xcelium"} {
+        if {$depth == 0} {
+          set depth "all"
+        }
+        probe "$scope" $probe_flags -depth $depth -memories -vcd
+      }
+    }
+
+    "evcd" {
+      if {$simulator eq "xcelium"} {
+        if {$depth == 0} {
+          set depth "all"
+        }
+        probe "$scope" $probe_flags -depth $depth -evcd
+      }
+    }
+
+    default {
+      puts "ERROR: Unknown wave format: ${waves}."
+      quit
+    }
+  }
+
+  puts "INFO: Dumping waves in scope \"$scope:$depth\"."
+}
+
+# A global variable representing the file id (fid) of the waves dumped in VPD format.
+setDefault vpd_fid 0
+
+# The entry point to enable dumping waves.
+#
+# If waves are not enabled (i.e. $waves == "none"), we do nothing. If enabled, then first, we run
+# the tcl command to establish the dump file. Then, we run `wavedumpScope args...` to enable dumping
+# the required hierarchies.
+global waves
+global simulator
+if {$waves ne "none"} {
+  set wavedump_db "waves.$waves"
+  puts "INFO: Dumping waves in [string toupper $waves] format to $wavedump_db."
+
+  # If waves are enabled, then issue the necessary tcl commands to enable the generation of waves.
+  # To explicitly list the hierarchies to dump, use the wavedumpScope proc instead.
+  switch $waves {
+    "fsdb" {
+      if {$simulator eq "xcelium"} {
+        call fsdbDumpfile $wavedump_db
+      } else {
+        fsdbDumpfile $wavedump_db
+      }
+    }
+
+    "shm" {
+      checkEq simulator "xcelium"
+      database -open $wavedump_db -default -shm
+    }
+
+    "vpd" {
+      checkEq simulator "vcs"
+      global vpd_fid
+      set vpd_fid [dump -file $wavedump_db -type VPD]
+    }
+
+    "vcd" {
+      if {$simulator eq "xcelium"} {
+        database -open $wavedump_db -default -vcd
+      } else {
+        puts "ERROR: Simulator $simulator does not support dumping waves in VCD."
+        quit
+      }
+    }
+
+    "evcd" {
+      if {$simulator eq "xcelium"} {
+        database -open $wavedump_db -default -evcd
+      } else {
+        puts "ERROR: Simulator $simulator does not support dumping waves in EVCD."
+        quit
+      }
+    }
+
+    default {
+      puts "ERROR: Unknown wave format: ${waves}."
+      quit
+    }
+  }
+
+  # Decide whether to dump the entire testbench hierarchy by default.
+  #
+  # If this variable is not set externally, it is set to 1 by default here. When set to 1, it adds
+  # the entire top-level testbench instance for dumping waves. For larger designs, this may slow
+  # down the simulation. The user can if needed, set it to 0 in the external tcl script that sources
+  # this script and manually add the hierarchies of interest in there, using the wavedumpScope proc.
+  # See the adjoining sim.tcl for an example.
+  setDefault dump_tb_top 1
+
+  if {$dump_tb_top == 1} {
+    global tb_top
+    wavedumpScope $waves $simulator $tb_top 0
+  } else {
+    puts "INFO: the hierarchies to be dumped are expected to be indicated externally."
+  }
+}

--- a/tools/dvsim/tools/xcelium/common.ccf
+++ b/tools/dvsim/tools/xcelium/common.ccf
@@ -1,0 +1,47 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Common coverage commands that apply to all DUTs.
+//
+// This coverge config file is provided by Xcelium and is located at:
+// ${XCELIUM_HOME}/tools/icc/include/all_coverage.ccf
+// Xcelium recommends including it, since it bundles together the common set of commands that enable
+// coverage collection on various design elements, that are otherwise turned off by default. We
+// maintain it locally with minor amends.
+
+// Enables expression coverage of various Verilog operators.
+set_expr_coverable_operators -all -event_or
+
+// Enables expression coverage of operators in various conditions and assignments.
+set_expr_coverable_statements -procassign -event_control -misc
+
+// Enables scoring of Verilog modules compiled with -v/-y or -libcell option but continues to
+// disable the scoring of Verilog modules defined with the 'celldefine compiler directive.
+set_libcell_scoring
+
+// Enables scoring of SystemVerilog continuous assignments, which is by disabled by default.
+set_assign_scoring
+
+// Scores branches together with block coverage.
+set_branch_scoring
+
+// Scores statements within a block.
+set_statement_scoring
+
+// Enables Toggle scoring and reporting of SystemVerilog enumerations and multidimensional static
+// arrays , vectors, packed union, modport and generate blocks.
+set_toggle_scoring -sv_enum enable_mda -sv_struct_with_enum -sv_modport -sv_mda 16 -sv_mda_of_struct -sv_generate -sv_packed_union
+
+// Enable toggle coverage only on ports.
+set_toggle_portsonly
+
+// Enable scoring of FSM arcs (state transitions).
+// TODO: re-enable this setting, temp disable due to #12544
+// set_fsm_arc_scoring
+
+// Include X->1|0 for toggle coverage collection. #10332
+set_toggle_includex
+
+// For ternary operator in default SOP mode
+set_expr_scoring -vlog_short_circuit

--- a/tools/dvsim/tools/xcelium/common_cov_excl.tcl
+++ b/tools/dvsim/tools/xcelium/common_cov_excl.tcl
@@ -1,0 +1,3 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0

--- a/tools/dvsim/tools/xcelium/cov_merge.tcl
+++ b/tools/dvsim/tools/xcelium/cov_merge.tcl
@@ -1,0 +1,26 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Merge coverage with IMC, across tests, scopes and previous regression runs.
+
+# Set the input coverage directories across all available scopes and previous runs,
+# using the env var 'cov_db_dirs' (which is a space separated list of directories).
+# Append each of these directories with /* wildcard at the end to allow the tool to
+# find all available test databases.
+set cov_db_dirs_env [string trim $::env(cov_db_dirs) " \"'"]
+foreach i $cov_db_dirs_env { append cov_db_dirs "[string trim $i]/* "; }
+puts "Input coverage directories:\n$cov_db_dirs"
+
+# Set the output directory for the merged database using the env var 'cov_merge_db_dir'.
+# The supplied env var may have quotes or spaces that needs to be trimmed.
+puts "Output directory for merged coverage:"
+set cov_merge_db_dir [string trim $::env(cov_merge_db_dir) " \"'"]
+
+# Run the merge command.
+merge $cov_db_dirs -out $cov_merge_db_dir -overwrite -initial_model union_all
+
+# Create a file with the path to the cover dirs
+# Replace spaces with newlines so each run is on its own line for the 'rank' command
+set cov_db_dirs_rank [string map {" " "\n"} [string trim $cov_db_dirs]]
+exec sh -c "cat << 'EOF' > $cov_merge_db_dir/runs.txt\n$cov_db_dirs_rank\nEOF"

--- a/tools/dvsim/tools/xcelium/cov_report.tcl
+++ b/tools/dvsim/tools/xcelium/cov_report.tcl
@@ -1,0 +1,60 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Generate reports for the merged coverage in HTML and text format.
+#
+# This file is passed to IMC using the -exec switch. Ensure that the merged coverage database, the
+# exclusion script and the coverage refinement files are passed to the IMC invocation using the
+# -load, -init and -load_refinement switches respectively (whichever ones are applicable).
+
+# Generate "detachable" reports that work despite browser Cross-Origin Request Security protection.
+# They have the downside that you have to select the .report file yourself in-browser.
+config reports.detachable_report_data -set true
+
+# Set the output directory for the reports database using the env var 'cov_report_dir'.
+# The supplied env var may have quotes or spaces that needs to be trimmed.
+set cov_report_dir [string trim $::env(cov_report_dir) " \"'"]
+
+# Set the input merged coverage database directory using the env var 'cov_merge_db_dir'.
+# The supplied env var may have quotes or spaces that needs to be trimmed.
+set cov_merge_db_dir [string trim $::env(cov_merge_db_dir) " \"'"]
+
+# Set the DUT name.
+set dut [string trim $::env(DUT_TOP)]
+set dut_uc [string toupper $dut]
+
+# Generate the text report (summary is sufficient).
+report -summary \
+  -inst uvm_pkg $dut \
+  -metrics all \
+  -all \
+  -cumulative on \
+  -local off \
+  -grading covered \
+  -out $cov_report_dir/cov_report.txt
+
+# Generate the functional coverage report for tracking.
+report -summary \
+  -type \
+  -all \
+  -metrics covergroup \
+  -source off \
+  -out $cov_report_dir/cov_report_cg.txt
+
+# Generate the HTML reports.
+report_metrics \
+  -out $cov_report_dir \
+  -overwrite \
+  -title $dut_uc \
+  -detail \
+  -metrics all \
+  -kind aggregate \
+  -source on \
+  -exclComments \
+  -assertionStatus \
+  -allAssertionCounters \
+  -all
+
+# rank the test runs
+rank -runfile $cov_merge_db_dir/runs.txt -html -out_html $cov_report_dir/grading -overwrite

--- a/tools/dvsim/tools/xcelium/cover.ccf
+++ b/tools/dvsim/tools/xcelium/cover.ccf
@@ -1,0 +1,10 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Include our common coverage CCF.
+include_ccf ${dv_root}/tools/xcelium/common.ccf
+
+// enable coverage on dut and below
+
+select_coverage -befts -module ${DUT_TOP}...

--- a/tools/dvsim/tools/xcelium/cover_reg_top.ccf
+++ b/tools/dvsim/tools/xcelium/cover_reg_top.ccf
@@ -1,0 +1,6 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Include our common coverage CCF.
+include_ccf ${dv_root}/tools/xcelium/common.ccf

--- a/tools/dvsim/tools/xcelium/cover_reg_top_toggle_excl
+++ b/tools/dvsim/tools/xcelium/cover_reg_top_toggle_excl
@@ -1,0 +1,3 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0

--- a/tools/dvsim/tools/xcelium/unr.cfg
+++ b/tools/dvsim/tools/xcelium/unr.cfg
@@ -1,0 +1,15 @@
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+check_unr -setup
+
+#Setup the clock and reset the design
+clock -infer
+reset ~dut.rst_ni
+get_reset_info
+
+set_prove_time_limit 5m
+check_unr -prove
+check_unr -list -type unreachable
+database -export_unicov
+report -detailed

--- a/tools/dvsim/vcs.hjson
+++ b/tools/dvsim/vcs.hjson
@@ -1,0 +1,366 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  build_cmd:  "{job_prefix} vcs"
+  build_ex:   "{build_dir}/simv"
+  run_cmd:    "{job_prefix} {build_ex}"
+
+  // This option enables the following: (needed for uvm_hdl_*)
+  //  - Read capability on registers, variables, and nets
+  //  - Write (deposit) capability on registers and variables
+  //  - Force capability on registers, variables, and nets
+  // TODO Trim this flag since +f hurts performance.
+  vcs_build_opt_debug_access: "-debug_access+f"
+  vcs_build_opt_debug_region: "-debug_region=cell+lib"
+  post_flist_opts: ""
+  build_opts: ["-sverilog -full64 -licqueue -ntb_opts uvm-1.2",
+               "-timescale={timescale}",
+               "-Mdir={build_ex}.csrc",
+               "-o {build_ex}",
+               "-f {sv_flist}",
+               "{post_flist_opts}",
+               // Enable LCA features. It does not require separate licenses.
+               "-lca",
+               // List multiple tops for the simulation. Prepend each top level with `-top`.
+               "{eval_cmd} echo {sim_tops} | sed -E 's/(\\S+)/-top \\1/g'",
+               "+incdir+{build_dir}",
+               // Turn on warnings for non-void functions called with return values ignored
+               "+warn=SV-NFIVC",
+               "+warn=noUII-L",
+               // Disable unnecessary LCA warning.
+               "+warn=noLCA_FEATURES_ENABLED",
+               // Disable warnings about bind directive not being applied.
+               "+warn=noBNA",
+               // Below option required for $error/$fatal system calls
+               "-assert svaext",
+               // Force unique and priority to evaluate compliance checking only on the stable
+               // and final value of the selection input at the end of a simulation timestep.
+               // See https://github.com/lowRISC/ibex/issues/845.
+               "-xlrm uniq_prior_final",
+               // Newer compiler versions have escalated these warnings into an error by default, and
+               // VCS generates code to build the simulation executable which fails these checks.
+               // De-escalate the error (only when building the simv itself.)
+               // > rmapats.c:20:9: error: implicit declaration of function 'vcs_simpSetEBlkEvtID'
+               // >  [-Wimplicit-function-declaration]
+               // > rmapats.c:466:36: error: passing argument 1 of 'setChildClockWriteFuncAndPcode' makes
+               // > integer from pointer without a cast
+               // >  [-Wint-conversion]
+               "-Xcflags='-Wno-error=implicit-function-declaration -Wno-error=int-conversion'",
+               // Force DPI-C compilation in C99 mode. The -fno-extended-identifiers flag tells g++
+               // not to worry about unicode. For some bizarre reason, the VCS DPI code contains
+               // preprocessor macros with smart quotes, which causes GCC 10.2 and later to choke
+               // otherwise. The double-escaped quotes are because this needs to go inside a string
+               // that gets passed to Make (stripping one level of quotes), and then needs to
+               // result in an argument with an embedded space (the other one).
+               "-CFLAGS --std=c99 -CFLAGS -fno-extended-identifiers",
+               // C++17 standard is enforced for all sources, including the DPI-C constructs.
+               "-CFLAGS --std=c++17",
+               // Without this magic LDFLAGS argument below, we get compile time errors with
+               // VCS on Google Linux machines that look like this:
+               // .../libvcsnew.so: undefined reference to `snpsReallocFunc'
+               // .../libvcsnew.so: undefined reference to `snpsCheckStrdupFunc'
+               // .../libvcsnew.so: undefined reference to `snpsGetMemBytes'
+               "-LDFLAGS -Wl,--no-as-needed",
+               // This option is needed for uvm_hdl_*, when it accesses the array under `celldefine
+               "{vcs_build_opt_debug_region}",
+               "{vcs_build_opt_debug_access}",
+               // Use this to conditionally compile for VCS (example: LRM interpretations differ
+               // across tools).
+               "+define+VCS",
+               // Upgrade below warnings to errors to make VCS more strict on syntax to avoid
+               // having issue with other simulators but passing with VCS
+               //
+               // Identifier previously declared
+               "-error=IPDW",
+               // Input Supply Port with no driver
+               "-error=UPF_ISPND",
+               // Invalid generic or parameter assignment
+               "-error=IGPA",
+               // Class scope used outside of class
+               "-error=PCSRMIO",
+               // Attempt to override undefined parameter
+               "-error=AOUP",
+               // Unbound component
+               "-error=ELW_UNBOUND",
+               // Illegal Use of Wildcard Index
+               "-error=IUWI",
+               // Index into non-array variable
+               "-error=INAV",
+               // Illegal Static Cast
+               "-error=SV-ISC",
+               // Obsolete System Verilog feature
+               "-error=OSVF-NPVIUFPI",
+               // Duplicate port in module instantiation
+               "-error=DPIMI",
+               // Identifier in ANSI port declaration
+               "-error=IPDASP",
+               // File not found
+               "-error=CM-HIER-FNF",
+               // Concatenations with unsized constants
+               "-error=CWUC",
+               // More arguments than needed
+               "-error=MATN",
+               // Specifying negative delays is invalid
+               "-error=STASKW_NDTAZ1",
+               // Too many parameter overrides
+               "-error=TMPO",
+               // Class objects must not hide other class members due to same name
+               "-error=SV-OHCM",
+               // ENUMASSIGN issues can cause LEC warnings later down the road (see #10083
+               // and #10952 for context). The warning is therefore promoted to an error
+               // in simulations in order to catch this as early as possible.
+               "-error=ENUMASSIGN",
+               // Tasks must not be enabled in functions. Other tools do not allow this.
+               "-error=TEIF"
+               // This helps avoid races in flops per Synopsys CASE 01552811.
+               // It causes flops to always use the sampled data value.
+               "-deraceclockdata"
+               ]
+
+  run_opts:   ["-licqueue",
+               "-ucli -do {run_script}",
+               "+ntb_random_seed={svseed}",
+               // In VCS, all random generation starts with an initial seed and that remains same
+               // for each instance of the module. Hence, for each instance of the same module
+               // $urandom() generates same random value.
+               "-xlrm hier_inst_seed",
+               // Disable the display of the SystemVerilog assert and cover statement summary
+               // at the end of simulation. This summary is list of assertions that started but
+               // did not finish because the simulation terminated, or assertions that did not
+               // fire at all. The latter is analyzed anyway in the collected coverage. Neither
+               // of these is useful in regular simulations.
+               "-assert nopostproc",
+               "+UVM_TESTNAME={uvm_test}",
+               "+UVM_TEST_SEQ={uvm_test_seq}"]
+
+  // Supported wave dumping formats (in order of preference).
+  supported_wave_formats: ["fsdb", "vpd"]
+
+  // Default tcl script used when running the sim. Override if needed.
+  run_script: "{dv_root}/tools/sim.tcl"
+
+  // Coverage related.
+  cov_db_dir: "{scratch_path}/coverage/{build_mode}.vdb"
+
+  // Individual test specific coverage data - this will be deleted if the test fails
+  // so that coverage from failiing tests is not included in the final report.
+  cov_db_test_dir_name: "{run_dir_name}.{svseed}"
+  cov_db_test_dir: "{cov_db_dir}/snps/coverage/db/testdata/{cov_db_test_dir_name}"
+
+  // Merging coverage.
+  // "cov_db_dirs" is a special variable that appends all build directories in use.
+  // It is constructed by the tool itself.
+  cov_merge_dir:    "{scratch_path}/cov_merge"
+  cov_merge_db_dir: "{cov_merge_dir}/merged.vdb"
+  cov_merge_cmd:    "{job_prefix} urg"
+  cov_merge_opts:   ["-lca",
+                     "-full64",
+                     // No need of generating report when merging coverage.
+                     "-noreport",
+                     // Parallel merge is slower than serial merge for most
+                     // small blocks, and the corresponding flags are commented
+                     // out. If this becomes problematic and you have a powerful
+                     // machine available, uncomment the three flags below.
+                     // Merge results from tests in parallel.
+                     // "-parallel",
+                     // "-parallel_split 20",
+                     // "-parallel_temproot {cov_merge_dir}",
+                     "+urg+lic+wait",
+                     // Merge same assert instances found in different VDBs.
+                     "-merge_across_libs",
+                     // This enables grading on the merged vdb.
+                     "-show tests",
+                     // Enable union mode of flexible merging for covergroups.
+                     "-flex_merge union",
+                     // Use cov_db_dirs var for dir args; append -dir in front of each
+                     "{eval_cmd} echo {cov_db_dirs} | sed -E 's/(\\S+)/-dir \\1/g'",
+                     "-dbname {cov_merge_db_dir}"]
+
+  // Generate coverage reports in text as well as html.
+  cov_report_dir:   "{scratch_path}/cov_report"
+  cov_report_cmd:   "{job_prefix} urg"
+  cov_report_opts:  ["-lca",
+                     "-full64",
+                     "+urg+lic+wait",
+                     // Lists all the tests that covered a given object.
+                     "-show tests",
+                     // Enable test grading using the "index" scheme, and the
+                     // generation of the list of contributing tests with
+                     // "testfile".
+                     "-grade index testfile",
+                     // Use simple ratio of total covered bins over total bins across cps & crs,
+                     "-group ratio",
+                     // Follow LRM naming conventions for array bins.
+                     "-group lrm_bin_name",
+                     // Compute overall coverage for per-instance covergroups individually rather
+                     // than cumulatively.
+                     "-group instcov_for_score",
+                     "-dir {cov_merge_db_dir}",
+                     "-line nocasedef",
+                     "-format both",
+                     // Prepend each el file with `-elfile`.
+                     "{eval_cmd} echo {vcs_cov_excl_files} | sed -E 's/(\\S+)/-elfile \\1/g'",
+                     "-report {cov_report_dir}"]
+  cov_report_txt:   "{cov_report_dir}/dashboard.txt"
+  cov_report_page:  "dashboard.html"
+
+  // UNR related.
+  // All code coverage, assert isn't supported
+  cov_unr_metrics: "line+cond+fsm+tgl+branch"
+  cov_unr_dir:     "{scratch_path}/cov_unr"
+
+  cov_unr_common_build_opts: ["-sverilog -full64 -licqueue -ntb_opts uvm-1.2",
+                              "-timescale={timescale}"]
+
+  // Use recommended UUM (Unified usage model) 3 steps flow. The other flow defines macro
+  // "SYNTHESIS", which we have used in design
+  cov_unr_build_cmd: [// Step 1
+                      "{job_prefix} vlogan {cov_unr_common_build_opts} &&",
+                      // Step 2
+                      "{job_prefix} vlogan {cov_unr_common_build_opts}",
+                      // grep all defines from {build_opts} from step 2
+                      '''{eval_cmd} opts=`echo {build_opts}`; defines=; d=; \
+                      for o in $opts; \
+                      do \
+                        d=`echo $o | grep -o '+define+.*'`; \
+                        defines="$defines $d"; \
+                      done; \
+                      echo $defines
+                      ''',
+                      "-f {sv_flist} &&",
+                      // Step 3
+                      "{job_prefix} vcs {cov_unr_common_build_opts}"]
+  cov_unr_build_opts: ["-cm {cov_unr_metrics}",
+                       "{vcs_cov_cfg_file}",
+                       "-unr={vcs_unr_cfg_file}",
+                       "{dut}"]
+
+  cov_unr_run_cmd:   ["{job_prefix} ./unrSimv"]
+  cov_unr_run_opts:  ["-unr"]
+
+  // Analyzing coverage - this is done by invoking --cov-analyze switch. It opens up the
+  // GUI for visual analysis.
+  cov_analyze_dir:  "{scratch_path}/cov_analyze"
+  cov_analyze_cmd:  "{job_prefix} verdi"
+  cov_analyze_opts: ["-cov",
+                     "-covdir {cov_merge_db_dir}",
+                     "-line nocasedef"
+                     "-elfile {vcs_cov_excl_files}"]
+
+  // Vars that need to exported to the env.
+  exports: [
+    { VCS_LICENSE_WAIT: 1 },
+    { VCS_ARCH_OVERRIDE: "linux" },
+    { VCS_LIC_EXPIRE_WARNING: 1 }
+  ]
+
+  // Defaults for VCS
+  // By default, collect all coverage metrics.
+  cov_metrics: "line+cond+fsm+tgl+branch+assert"
+
+  // Supply the cov configuration file.
+  // Note that this needs to be set as `-cm_hier <file>`.
+  // Include hierarchies for both code coverage and assertions.
+  vcs_cov_cfg_file: ""
+
+  // Supply cov configuration file for -cm_fsmresetfilter.
+  vcs_fsm_reset_cov_cfg_file: ""
+
+  // Supply the cov exclusion files.
+  vcs_cov_excl_files: []
+
+  // pass and fail patterns
+  build_fail_patterns: ["^Error-.*$"]
+  run_fail_patterns:   ["^Error-.*$"] // Null pointer error
+
+  build_modes: [
+    {
+      name: vcs_gui
+      is_sim_mode: 1
+      build_opts: ["-debug_access+all+reverse"]
+      run_opts: ["-gui", "-l {run_dir}/simv.log"]
+    }
+    {
+      name: vcs_gui_debug
+      // TODO as done for Xcelium see PR #24156
+      is_sim_mode: 1
+      build_opts: ["-debug_access+all+reverse"]
+      run_opts: ["-gui", "-l {run_dir}/simv.log"]
+    }
+    {
+      name: vcs_waves
+      is_sim_mode: 1
+      build_opts: [// Enable generating Verdi Knowledge Database
+                   "-kdb",
+                   "-debug_access"]
+    }
+    {
+      name: vcs_waves_off
+      is_sim_mode: 1
+      build_opts: [// disable dumping assertion failures to improve runtime performance
+                   "-assert dbgopt"]
+    }
+    {
+      name: vcs_cov
+      is_sim_mode: 1
+      build_opts: [// Enable the required cov metrics
+                   "-cm {cov_metrics}",
+                   // Set the coverage hierarchy
+                   "{vcs_cov_cfg_file}",
+                   "-cm_common_hier",
+                   // Cover all continuous assignments
+                   "-cm_line contassign",
+                   // Dump toggle coverage on mdas, array of structs and on ports only
+                   "-cm_tgl mda+structarr+portsonly",
+                   // Report condition coverage within tasks, functions and for loops.
+                   "-cm_cond for",
+                   // Ignore initial blocks for coverage
+                   "-cm_report noinitial",
+                   // Filter unreachable/statically constant blocks. seqnoconst does a more
+                   // sophisticated analysis including NBA / assignment with delays.
+                   "-cm_seqnoconst",
+                   // Creates a constfile.txt indicating a list of detected constants.
+                   "-diag noconst"
+                   // Don't count coverage that's coming from zero-time glitches
+                   "-cm_glitch 0",
+                   // Ignore warnings about not applying cm_glitch to path and FSM
+                   "+warn=noVCM-OPTIGN",
+                   // Coverage database output location
+                   "-cm_dir {cov_db_dir}",
+                   // The following option is to improve runtime performance
+                   "-Xkeyopt=rtopt",
+                   // Exclude FSM transitions that can only happen on reset
+                   "-cm_fsmresetfilter {vcs_fsm_reset_cov_cfg_file}",
+                   ]
+
+      run_opts:   [// Enable the required cov metrics
+                   "-cm {cov_metrics}",
+                   // Same directory as build
+                   "-cm_dir {cov_db_dir}",
+                   // Don't output cm.log which can be quite large
+                   "-cm_log /dev/null",
+                   // Provide a name to the coverage collected for this test
+                   "-cm_name {cov_db_test_dir_name}"]
+    }
+    {
+      name: vcs_xprop
+      is_sim_mode: 1
+      build_opts: ["-xprop={vcs_xprop_cfg_file}",
+                   // Enable xmerge mode specific performance optimization
+                   "-xprop=mmsopt"]
+    }
+    {
+      name: vcs_profile
+      is_sim_mode: 1
+      build_opts: ["-simprofile"]
+      run_opts:   ["-simprofile {profile}"]
+    }
+    {
+      name: vcs_loopdetect
+      is_sim_mode: 1
+      build_opts: ["+vcs+loopreport", "+vcs+loopdetect"]
+      run_opts:   ["+vcs+loopreport", "+vcs+loopdetect"]
+    }
+  ]
+}

--- a/tools/dvsim/xcelium.hjson
+++ b/tools/dvsim/xcelium.hjson
@@ -1,0 +1,277 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  build_cmd:  "{job_prefix} xrun"
+  run_cmd:    "{job_prefix} xrun"
+
+  build_db_dir: "{build_dir}/xcelium.d"
+
+  build_opts: ["-elaborate -64bit -sv",
+               // Wait to acquire a license.
+               "-licqueue",
+               // TODO: duplicate primitives between OT and Ibex #1231
+               "-ALLOWREDEFINITION",
+               "-messages -errormax 50",
+               "-timescale {timescale}",
+               "-f {sv_flist}",
+               "-uvmhome CDNS-1.2",
+               // Specify the library name for the run step to use.
+               "-xmlibdirname {build_db_dir}",
+               // List multiple tops for the simulation. Prepend each top level with `-top`.
+               "{eval_cmd} echo {sim_tops} | sed -E 's/(\\S+)/-top \\1/g'",
+               // Set the top level elaborated entity (snapshot name) correctly since there are
+               // multiple tops.
+               "-snapshot {tb}",
+               // for uvm_hdl_* used by csr backdoor
+               "-access +rw",
+               // This is to fix a timescale issue due to using `resetall to reset timescale and
+               // `-sv` compile option. #7178
+               "-enable_strict_timescale",
+               // Use this to conditionally compile for Xcelium (example: LRM interpretations differ
+               // across tools).
+               "+define+XCELIUM",
+               // Suppress printing of the copyright banner.
+               "-nocopyright",
+               // Ignore "timescale is not specified for the package" warning
+               "-nowarn TSNSPK",
+               // Ignore "IEEE 1800-2009 SystemVerilog simulation semantics" warning
+               "-nowarn DSEMEL",
+               // Ignore hierarchial ref warnings in interfaces
+               "-nowarn CUVIHR",
+               // Ignore warning "Potentially reversed dist range may cause it to be treated as
+               // empty". This is thrown when and expression like `var - 1` is added to a
+               // randomization distribution, which can potentially be a negative value.
+               "-nowarn REVRNG",
+               // Ignore warning "Include directory <path> given but not used". This is benign.
+               "-nowarn SPDUSD",
+               // Ignore "cds.lib Invalid path ... command ignored" warnings emitted by Xcelium's
+               // bundled cdsvhdl.lib referencing VHDL library directories that don't exist in the
+               // install. Benign for SV-only flows.
+               "-nowarn DLCPTH",
+               // This warning is thrown when a scalar enum variable is assigned to an enum array.
+               // Other tools (e.g., FPV) treat such assignments as an error, hence we bump it to
+               // an error in simulation so that this can be caught early in CI.
+               "-xmerror ENUMERR",
+               // Enables LRM compliant behavior for $asserton, $assertoff and $assertkill tasks.
+               "-enable_abv_asrtctrl_enh"
+               ]
+
+  // We want to allow the possibility of passing no test or no test sequence. Unfortunately,
+  // Xcelium generates an error (*E,OPTP2ND) if you pass an empty plusarg. To avoid doing so, these
+  // two variables expand to e.g. "+UVM_TESTNAME=foo" if we have a test and the empty string if
+  // not.
+  uvm_testname_plusarg: "{eval_cmd} echo {uvm_test} | sed -E 's/(.+)/+UVM_TESTNAME=\\1/'"
+  uvm_testseq_plusarg: "{eval_cmd} echo {uvm_test_seq} | sed -E 's/(.+)/+UVM_TEST_SEQ=\\1/'"
+
+  run_opts:   ["-input {run_script}",
+               // Suppress printing of the copyright banner.
+               "-nocopyright",
+               // Wait to acquire a license.
+               "-licqueue",
+               "-64bit -xmlibdirname {build_db_dir}",
+               // Use the same snapshot name set during the build step.
+               "-r {tb}",
+               "+SVSEED={svseed}",
+               "{uvm_testname_plusarg}",
+               "{uvm_testseq_plusarg}",
+               // Ignore "IEEE 1800-2009 SystemVerilog simulation semantics" warning
+               "-nowarn DSEM2009",
+               // Ignore "cds.lib Invalid path ... command ignored" warnings emitted by Xcelium's
+               // bundled cdsvhdl.lib referencing VHDL library directories that don't exist in the
+               // install. Benign for SV-only flows.
+               "-nowarn DLCPTH",
+               ]
+
+  // Vars that need to exported to the env.
+  exports: [
+    // Poll for an available license in all servers.
+    { CDS_LIC_QUEUE_POLL: 1 },
+
+    // Poll for an available license every 1 min.
+    { CDS_LIC_QUEUE_POLL_INT: 60 },
+
+    // X-prop related: these were suggested by Xcelium as warnings during the build time.
+    // These enable array corruption when the index is out of range or invalid.
+    { VL_ENABLE_INVALID_IDX_XPROP: 1 },
+    { VL_ENABLE_OUTOFRANGE_IDX_XPROP: 1 },
+
+    // Export the cov_report path so that the tcl file can read these as env vars.
+    { cov_merge_db_dir: "{cov_merge_db_dir}" },
+    { cov_report_dir: "{cov_report_dir}" }
+
+    // Export unr related paths for make
+    {cov_unr_dir:     "{cov_unr_dir}" }
+    // Add an additional single quotation because `cov_merge_cmd` has an empty space, it will cause
+    // trouble when exporting the entire command in the environment.
+    {cov_merge_cmd: "{cov_merge_cmd}"}
+
+    // job prefix
+    {job_prefix: "{job_prefix}"}
+
+  ]
+
+  // Supported wave dumping formats (in order of preference).
+  supported_wave_formats: ["shm", "fsdb", "vcd"]
+
+  // Default tcl script used when running the sim. Override if needed.
+  run_script: "{dv_root}/tools/sim.tcl"
+
+  // Coverage related.
+  // By default, collect all coverage metrics: block:expr:fsm:toggle:functional.
+  cov_metrics: all
+
+  // Supply the cov configuration file.
+  // Note that this needs to be set as -covfile <file>.
+  xcelium_cov_cfg_file: ""
+
+  // Supply the cov exclusion tcl script - passed on to IMC using the -init switch.
+  xcelium_cov_excl_script: ""
+
+  // Supply the cov refinement files - passed on to IMC using the -load_refinement switch.
+  xcelium_cov_refine_files: []
+
+  // Set the coverage directories.
+  cov_work_dir: "{scratch_path}/coverage"
+  cov_db_dir:   "{cov_work_dir}/{build_mode}"
+
+  // Individual test specific coverage data - this will be deleted if the test fails
+  // so that coverage from failiing tests is not included in the final report.
+  cov_db_test_dir_name: "{run_dir_name}.{svseed}"
+  cov_db_test_dir:      "{cov_db_dir}/{cov_db_test_dir_name}"
+
+  // Merging coverage.
+  // It is constructed by the tool itself.
+  cov_merge_dir:    "{scratch_path}/cov_merge"
+  cov_merge_db_dir: "{cov_merge_dir}/merged"
+  cov_merge_cmd:    "imc"
+  cov_merge_opts:   ["-64bit",
+                     "-licqueue",
+                     "-exec {dv_root}/tools/xcelium/cov_merge.tcl"]
+
+  // Generate covreage reports in text as well as html.
+  cov_report_dir:   "{scratch_path}/cov_report"
+  cov_report_cmd:   "{job_prefix} imc"
+  cov_report_opts:  ["-64bit",
+                     "-licqueue",
+                     "-load {cov_merge_db_dir}",
+                     " {eval_cmd} echo {xcelium_cov_excl_script} | sed -E 's/(\\S+)/-init \\1/g' ",
+                     " {eval_cmd} echo {xcelium_cov_refine_files} | sed -E 's/(\\S+)/-load_refinement \\1/g' ",
+                     "-exec {dv_root}/tools/xcelium/cov_report.tcl"]
+  cov_report_txt:   "{cov_report_dir}/cov_report.txt"
+  cov_report_page:  "index.html"
+
+  // Analyzing coverage - this is done by invoking --cov-analyze switch. It opens up the
+  // GUI for visual analysis.
+  cov_analyze_dir:  "{scratch_path}/cov_analyze"
+  cov_analyze_cmd:  "{job_prefix} imc"
+  cov_analyze_opts: ["-64bit",
+                     "-licqueue",
+                     "-load {cov_merge_db_dir}",
+                     " {eval_cmd} echo {xcelium_cov_excl_script} | sed -E 's/(\\S+)/-init \\1/g' ",
+                     " {eval_cmd} echo {xcelium_cov_refine_files} | sed -E 's/(\\S+)/-load_refinement \\1/g' "]
+
+  cov_unr_dir:     "{scratch_path}/cov_unr"
+
+  // not needed we can reuse the last build snapshot
+  cov_unr_build_opts:[]
+  cov_unr_build_cmd:[]
+
+  cov_unr_run_cmd: "{job_prefix} xrun"
+
+
+  cov_unr_run_opts: [// use xrun in UNR mode
+                     "-unr",
+                     // JasperGold switch (use formal)
+                     "-jg",
+                     // use the same snapshot as used for regression
+                     "-r {tb}",
+                     // pointer to the merged coverage data from the regression
+                     "-covdb {cov_merge_db_dir}",
+                     // what metrics to use
+                     "-jg_coverage {cov_metrics}",
+                     "-64bit",
+                     "-xmlibdirname {build_db_dir}",
+                     "-jgargs '-allow_unsupported_OS'",
+                     // overwrite previous results
+                     "-covoverwrite",
+                     "-inst_top {dut_instance}",
+                     // UNR Configurations
+                     "-input {xcelium_unr_cfg_file} "]
+
+
+  // pass and fail patterns
+  build_fail_patterns: ["\\*E.*$"]
+  run_fail_patterns:   ["\\*E.*$"] // Null pointer error
+
+  build_modes: [
+    {
+      name: xcelium_gui
+      is_sim_mode: 1
+      build_opts: ["-createdebugdb", "-access +c"]
+      run_opts: ["-gui"]
+    }
+    {
+      name: xcelium_gui_debug
+      is_sim_mode: 1
+      build_opts: ["-createdebugdb", "-access +c", "-uvmlinedebug", "-linedebug",
+                   "+uvm_set_config_int=*,recording_detail,1"]
+      run_opts: ["-gui",
+                 "-input '@database -open waves -into waves.shm -default; probe -create \n"
+                 "tb -depth all -packed 32k -unpacked 32k -all -dynamic -database waves'",
+                 "+uvm_set_config_int=*,recording_detail,1"]
+    }
+    {
+      name: xcelium_waves
+      is_sim_mode: 1
+      build_opts: ["-access +c"]
+    }
+    {
+      name: xcelium_waves_off
+      is_sim_mode: 1
+      build_opts: []
+    }
+    {
+      name: xcelium_cov
+      is_sim_mode: 1
+      build_opts: [// Enable the required cov metrics.
+                   "-coverage {cov_metrics}",
+                   // Limit the scope of coverage collection to the DUT.
+                   "-covdut {dut}",
+                   // Set the coverage configuration file
+                   "-covfile {xcelium_cov_cfg_file}",
+                   // Don't warn about the switches we set that will be default in future releases.
+                   "-nowarn COVDEF",
+                  ]
+      run_opts:   [// Put the coverage model (*.ucm) and the database (*.ucd) together.
+                   "-covmodeldir {cov_db_test_dir}",
+                   // Coverage database output location.
+                   "-covworkdir {cov_work_dir}",
+                   // Set the scope to the build mode name.
+                   "-covscope {build_mode}",
+                   // Test coverage dir name to create under cov_db_dir.
+                   "-covtest {cov_db_test_dir_name}",
+                   // Overwrite the coverage data of a specific test/seed if it already exists.
+                   "-covoverwrite"]
+    }
+    // TODO support profile for xcelium
+    {
+      name: xcelium_profile
+      is_sim_mode: 1
+      build_opts: ["-perfstat"]
+      run_opts:   ["-perfstat", "-perflog perfstat.log"]
+    }
+    {
+      name: xcelium_xprop
+      is_sim_mode: 1
+      build_opts: ["-xprop F -xverbose"]
+    }
+    {
+      // TODO: Add build and run options to enable zero delay loop detection.
+      name: xcelium_loopdetect
+      is_sim_mode: 1
+      build_opts: []
+      run_opts:   []
+    }
+  ]
+}


### PR DESCRIPTION
We want to add the necessary configuration and tooling infrastructure to run design verification (DV) simulations using the DVSim flow:
    
    - New `flake.nix`: Defines the hermetic `caliptra-dvsim` development shell. 
      It provisions all required Python packages (including `dvsim`, `compile-to-core`, 
      and FuseSoC), builds C DPI dependencies (such as OpenSSL), and configures 
      environment variables and `LD_LIBRARY_PATH` required by EDA simulators.
    
    - Copy `tools/dvsim/` from caliptra-rtl: Imports the core DVSim Python package 
      definitions, base simulation configurations (`*.hjson`), and the simulation 
      Makefile (`sim.mk`). This directory is copied directly into the repository 
      because Nix flakes require all evaluated inputs and package sources to be 
      tracked inside the Git tree to guarantee reproducible, hermetic builds.
